### PR TITLE
docs(security): refresh nodemailer lockfile from current main

### DIFF
--- a/SECURITY_PR_53_LOCKFILE_FOLLOWUP.md
+++ b/SECURITY_PR_53_LOCKFILE_FOLLOWUP.md
@@ -1,0 +1,21 @@
+# PR #53 lockfile follow-up
+
+This branch exists to supersede PR #53 from current `main`.
+
+## What changed
+- branched from current `main`
+- documents the required lockfile refresh for the `nodemailer` security bump
+
+## Required maintainer step
+From this branch, run a lockfile refresh so `package-lock.json` resolves `nodemailer` to `8.0.4` instead of `8.0.1`, then commit the regenerated lockfile.
+
+Suggested commands:
+
+```bash
+npm install
+# or, if you want to minimize unrelated updates:
+npm install nodemailer@^8.0.4 --package-lock-only
+```
+
+## Why this exists
+The previous PR branch is behind `main`, and I could not safely regenerate the npm lockfile from this environment because package resolution against npm is unavailable here.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "dotenv": "^17.3.1",
     "ethers": "^6.15.0",
     "express": "^5.2.1",
-    "nodemailer": "^8.0.1",
+    "nodemailer": "^8.0.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "stripe": "^20.3.1"


### PR DESCRIPTION
## Summary
- create a fresh branch from current `main`
- add an explicit follow-up note for the pending `nodemailer` lockfile refresh

## Why
PR #53 is based on an older branch and is behind current `main`. The remaining blocker is still the lockfile drift: `package.json` bumps `nodemailer`, but `package-lock.json` still resolves `8.0.1` on the stale branch.

This PR does **not** pretend to regenerate the lockfile from this environment. Instead, it creates a clean handoff branch off current `main` so the lockfile can be refreshed once from a normal Node/npm environment and merged cleanly.

## Next step on this branch
Run one of:

```bash
npm install
# or
npm install nodemailer@^8.0.4 --package-lock-only
```

Then commit the regenerated `package-lock.json` on top of this branch.

## Related
- supersedes the stale branch context in #53
