### PR TITLE
Harden admin dashboard initializer rendering

### DIFF
--- a/admin-dashboard-init.js
+++ b/admin-dashboard-init.js
@@ -2,38 +2,63 @@
 // Extracted from inline <script> in admin-dashboard.html
 
 async function fetchAllPayments() {
-  // For demo, fetch a flat file or extend backend for admin
   const res = await fetch('/api/all-payments');
   if (!res.ok) return [];
   const data = await res.json();
   return data.payments || [];
 }
 
+function el(tag, { text, attrs } = {}) {
+  const node = document.createElement(tag);
+  if (text !== undefined) node.textContent = String(text);
+  if (attrs) {
+    Object.entries(attrs).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) node.setAttribute(key, String(value));
+    });
+  }
+  return node;
+}
+
+function clear(node) {
+  if (node) node.replaceChildren();
+}
+
+function paymentCell(value) {
+  return el('td', { text: value });
+}
+
+function buildPaymentRow(payment) {
+  const row = document.createElement('tr');
+  row.appendChild(paymentCell(payment.user || '-'));
+  row.appendChild(paymentCell(payment.date ? new Date(payment.date).toLocaleString() : '-'));
+  row.appendChild(paymentCell(`${payment.amount} ${payment.currency}`));
+  row.appendChild(paymentCell(payment.status || '-'));
+
+  const txCell = document.createElement('td');
+  if (payment.txid) {
+    txCell.appendChild(el('a', { text: 'View', attrs: { href: payment.txid, target: '_blank', rel: 'noopener' } }));
+  } else {
+    txCell.textContent = '-';
+  }
+  row.appendChild(txCell);
+  row.appendChild(paymentCell(payment.gateway || 'Coinbase'));
+  return row;
+}
+
 async function renderAdminPayments() {
   const table = document.getElementById('adminPaymentTableBody');
   if (!table) return;
   const payments = await fetchAllPayments();
+  clear(table);
   if (!payments.length) {
-    table.innerHTML = '<tr><td colspan="6">No payments found.</td></tr>';
+    const row = document.createElement('tr');
+    row.appendChild(el('td', { text: 'No payments found.', attrs: { colspan: '6' } }));
+    table.appendChild(row);
     return;
   }
-  table.innerHTML = payments
-    .map(
-      (p) => `
-    <tr>
-      <td>${p.user || '-'}</td>
-      <td>${p.date ? new Date(p.date).toLocaleString() : '-'}</td>
-      <td>${p.amount} ${p.currency}</td>
-      <td>${p.status || '-'}</td>
-      <td>${p.txid ? `<a href="${p.txid}" target="_blank">View</a>` : '-'}</td>
-      <td>${p.gateway || 'Coinbase'}</td>
-    </tr>
-  `,
-    )
-    .join('');
+  payments.forEach((payment) => table.appendChild(buildPaymentRow(payment)));
 }
 
-// Navigation logic to switch sections
 document.addEventListener('DOMContentLoaded', () => {
   renderAdminPayments();
   const navLinks = document.querySelectorAll('.nav-link');
@@ -45,11 +70,8 @@ document.addEventListener('DOMContentLoaded', () => {
       this.classList.add('active');
       const target = this.getAttribute('href').replace('#', '');
       sections.forEach((section) => {
-        if (section.id === target) {
-          section.classList.add('active');
-        } else {
-          section.classList.remove('active');
-        }
+        if (section.id === target) section.classList.add('active');
+        else section.classList.remove('active');
       });
     });
   });


### PR DESCRIPTION
Replace HTML string-based payment table rendering in admin-dashboard-init.js with DOM node construction for both the empty state and payment rows. This removes another live initializer innerHTML path while preserving the current admin dashboard UX.