### PR TITLE
Load wallet DOM override module from wallet HTML

### DIFF
--- a/aetheron-wallet.html
+++ b/aetheron-wallet.html
@@ -1224,5 +1224,6 @@
     </div>
 
     <script src="aetheron-wallet.js"></script>
+    <script type="module" src="aetheron-wallet-dom-overrides.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This activates the previously merged wallet DOM hardening layer by loading `aetheron-wallet-dom-overrides.js` from `aetheron-wallet.html` after the existing `aetheron-wallet.js` script. This is the smallest activation patch needed to make the safe wallet renderer overrides execute on the page.