### PR TITLE
Add safe render overrides for live dashboard UI

### DIFF
--- a/dashboard-dom-overrides.js
+++ b/dashboard-dom-overrides.js
@@ -1,0 +1,256 @@
+import {
+  createWalletChooserModal,
+  renderWalletChooserOptions,
+  createSimpleModal,
+  renderTxHistoryTableBody,
+  renderRewardList,
+  renderAchievements,
+  createTradeNotification,
+} from './dashboard-safe-renderers.js';
+
+function patchDashboardMain() {
+  const g = window;
+
+  const originalEnsureWalletChooser = g.ensureWalletChooser;
+  g.ensureWalletChooser = function () {
+    let modal = document.getElementById('walletChooserModal');
+    if (modal) return modal;
+
+    modal = createWalletChooserModal();
+    document.body.appendChild(modal);
+
+    const closeButton = document.getElementById('closeWalletChooserBtn');
+    if (closeButton) {
+      closeButton.addEventListener('click', g.closeWalletChooser);
+    }
+
+    modal.addEventListener('click', (event) => {
+      if (event.target === modal) {
+        g.closeWalletChooser();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        g.closeWalletChooser();
+      }
+    });
+
+    return modal;
+  };
+
+  const originalRenderWalletChooserOptions = g.renderWalletChooserOptions;
+  g.renderWalletChooserOptions = function () {
+    const optionsContainer = document.getElementById('walletChooserOptions');
+    if (!optionsContainer) return;
+
+    const injectedProviders = typeof g.getInjectedProviders === 'function' ? g.getInjectedProviders() : [];
+    const chooserOptions = [];
+    const seenChoices = new Set();
+
+    injectedProviders.forEach((providerOption) => {
+      const label = typeof g.getInjectedProviderLabel === 'function' ? g.getInjectedProviderLabel(providerOption) : 'Browser Wallet';
+      const choice = label === 'MetaMask' ? 'metamask' : label === 'Coinbase Wallet' ? 'coinbase' : 'browser';
+      if (seenChoices.has(choice)) return;
+      seenChoices.add(choice);
+      chooserOptions.push({
+        choice,
+        label,
+        helper: label === 'MetaMask' ? 'Connect with MetaMask extension or mobile app' : `Connect with ${label}`,
+      });
+    });
+
+    chooserOptions.push({
+      choice: 'walletconnect',
+      label: 'WalletConnect',
+      helper: 'Scan with a mobile wallet',
+    });
+
+    if (chooserOptions.length === 1 && chooserOptions[0].choice === 'walletconnect') {
+      chooserOptions.unshift(
+        { choice: 'install-metamask', label: 'Get MetaMask', helper: 'Install the MetaMask browser extension' },
+        { choice: 'install-coinbase', label: 'Get Coinbase Wallet', helper: 'Install the Coinbase Wallet extension' },
+      );
+    }
+
+    renderWalletChooserOptions(optionsContainer, chooserOptions);
+
+    optionsContainer.querySelectorAll('[data-wallet-choice]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const walletChoice = button.dataset.walletChoice;
+        g.closeWalletChooser();
+
+        if (walletChoice === 'walletconnect') {
+          if (typeof g.connectWalletConnect === 'function') {
+            await g.connectWalletConnect();
+          } else {
+            g.showToast?.('WalletConnect is still loading. Please try again.', { type: 'error' });
+          }
+          return;
+        }
+
+        if (walletChoice === 'install-metamask') {
+          window.open('https://metamask.io/download/', '_blank', 'noopener');
+          return;
+        }
+
+        if (walletChoice === 'install-coinbase') {
+          window.open('https://www.coinbase.com/wallet/downloads', '_blank', 'noopener');
+          return;
+        }
+
+        await g.connectWallet?.({ auto: false, walletType: walletChoice });
+      });
+    });
+  };
+
+  if (typeof originalEnsureWalletChooser !== 'function' || typeof originalRenderWalletChooserOptions !== 'function') {
+    // no-op; the overrides above still provide the safer path if globals are used later
+  }
+}
+
+function patchDashboardApp() {
+  const dashboard = window.dashboard;
+  if (!dashboard) return false;
+
+  dashboard.renderTxHistory = function () {
+    const tableBody = document.getElementById('txHistoryTable')?.querySelector('tbody');
+    const type = document.getElementById('txTypeFilter')?.value || 'all';
+    const date = document.getElementById('txDateFilter')?.value || '';
+    if (!tableBody) return;
+
+    let txs = this.getTxHistory();
+    if (type !== 'all') txs = txs.filter((tx) => tx.type === type);
+    if (date) txs = txs.filter((tx) => String(tx.date || '').startsWith(date));
+    renderTxHistoryTableBody(tableBody, txs);
+  };
+
+  dashboard.updateTradingRewards = function () {
+    const progressBar = document.getElementById('volume-progress');
+    const progressText = document.getElementById('volume-text');
+    const rewardsList = document.getElementById('trading-rewards');
+
+    if (progressBar && progressText) {
+      const progress = (this.tradingRewards.currentProgress / this.tradingRewards.dailyTarget) * 100;
+      progressBar.style.width = `${Math.min(progress, 100)}%`;
+      progressText.textContent = `$${this.tradingRewards.currentProgress.toFixed(0)} / $${this.tradingRewards.dailyTarget}`;
+    }
+
+    if (rewardsList) {
+      renderRewardList(rewardsList, this.tradingRewards.rewards, this.tradingRewards.currentProgress);
+    }
+  };
+
+  dashboard.updateAchievements = function () {
+    const achievementsList = document.getElementById('achievements-list');
+    if (achievementsList) {
+      renderAchievements(achievementsList, this.achievements);
+    }
+  };
+
+  dashboard.showTradeNotification = function (amount) {
+    const notification = createTradeNotification(amount);
+    document.body.appendChild(notification);
+    setTimeout(() => notification.remove(), 3000);
+  };
+
+  window.createDashboardModal = function (contentHtml) {
+    if (typeof contentHtml !== 'string') {
+      return createSimpleModal({ titleText: '', bodyNodes: [] });
+    }
+
+    if (contentHtml.includes('Edit Profile')) {
+      const nameLabel = document.createElement('label');
+      nameLabel.textContent = 'Name: ';
+      const nameInput = document.createElement('input');
+      nameInput.id = 'profileNameInput';
+      nameInput.type = 'text';
+      nameInput.value = 'Alex';
+      nameLabel.appendChild(nameInput);
+
+      const emailLabel = document.createElement('label');
+      emailLabel.textContent = 'Email: ';
+      const emailInput = document.createElement('input');
+      emailInput.id = 'profileEmailInput';
+      emailInput.type = 'email';
+      emailInput.value = 'alex@email.com';
+      emailLabel.appendChild(emailInput);
+
+      const br1 = document.createElement('br');
+      const br2 = document.createElement('br');
+
+      const save = document.createElement('button');
+      save.id = 'saveProfileBtn';
+      save.type = 'button';
+      save.textContent = 'Save';
+
+      const close = document.createElement('button');
+      close.id = 'closeProfileModalBtn';
+      close.type = 'button';
+      close.textContent = 'Close';
+
+      const modal = createSimpleModal({
+        titleText: 'Edit Profile',
+        bodyNodes: [nameLabel, br1, emailLabel, br2],
+        actionButtons: [save, close],
+      });
+      document.body.appendChild(modal);
+      return modal;
+    }
+
+    if (contentHtml.includes('Welcome to Aetheron!')) {
+      const paragraph = document.createElement('p');
+      paragraph.textContent = 'Your browser can open the onboarding walkthrough when the video asset is available.';
+      const close = document.createElement('button');
+      close.id = 'closeVideoModalBtn';
+      close.type = 'button';
+      close.textContent = 'Close';
+      const modal = createSimpleModal({ titleText: 'Welcome to Aetheron!', bodyNodes: [paragraph], actionButtons: [close] });
+      document.body.appendChild(modal);
+      return modal;
+    }
+
+    if (contentHtml.includes('Gamified Tutorial')) {
+      const paragraph = document.createElement('p');
+      paragraph.textContent = 'Complete tasks to earn badges and rewards!';
+      const list = document.createElement('ul');
+      ['Connect your wallet ❌', 'Make your first trade ❌', 'Vote in governance ❌'].forEach((text) => {
+        const li = document.createElement('li');
+        li.textContent = text;
+        list.appendChild(li);
+      });
+      const close = document.createElement('button');
+      close.id = 'closeTutorialModalBtn';
+      close.type = 'button';
+      close.textContent = 'Close';
+      const modal = createSimpleModal({ titleText: 'Gamified Tutorial', bodyNodes: [paragraph, list], actionButtons: [close] });
+      document.body.appendChild(modal);
+      return modal;
+    }
+
+    const fallbackText = document.createElement('p');
+    fallbackText.textContent = 'Modal content is available.';
+    const modal = createSimpleModal({ titleText: 'Aetheron Modal', bodyNodes: [fallbackText] });
+    document.body.appendChild(modal);
+    return modal;
+  };
+
+  return true;
+}
+
+function initPatches() {
+  patchDashboardMain();
+  if (!patchDashboardApp()) {
+    const retry = () => {
+      if (patchDashboardApp()) return;
+      setTimeout(retry, 250);
+    };
+    retry();
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initPatches);
+} else {
+  initPatches();
+}

--- a/dashboard-safe-renderers.js
+++ b/dashboard-safe-renderers.js
@@ -1,0 +1,155 @@
+export function clearNode(node) {
+  if (!node) return;
+  node.replaceChildren();
+}
+
+export function createWalletChooserModal() {
+  const modal = document.createElement('div');
+  modal.id = 'walletChooserModal';
+  modal.className = 'modal-bg';
+  modal.hidden = true;
+
+  const dialog = document.createElement('div');
+  dialog.className = 'modal wallet-chooser-modal';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.setAttribute('aria-labelledby', 'walletChooserTitle');
+
+  const closeButton = document.createElement('button');
+  closeButton.type = 'button';
+  closeButton.className = 'close-modal-btn';
+  closeButton.id = 'closeWalletChooserBtn';
+  closeButton.setAttribute('aria-label', 'Close Wallet Chooser');
+  closeButton.textContent = '×';
+
+  const title = document.createElement('h3');
+  title.id = 'walletChooserTitle';
+  title.textContent = 'Choose a wallet';
+
+  const subtitle = document.createElement('p');
+  subtitle.className = 'text-muted';
+  subtitle.textContent = 'Connect with an installed wallet or use WalletConnect.';
+
+  const options = document.createElement('div');
+  options.id = 'walletChooserOptions';
+  options.className = 'modal-actions wallet-chooser-options';
+
+  dialog.append(closeButton, title, subtitle, options);
+  modal.appendChild(dialog);
+  return modal;
+}
+
+export function renderWalletChooserOptions(container, chooserOptions) {
+  clearNode(container);
+  for (const option of chooserOptions) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn wallet-choice-btn';
+    button.dataset.walletChoice = option.choice;
+    button.setAttribute('aria-label', option.label);
+
+    const strong = document.createElement('strong');
+    strong.textContent = option.label;
+    const span = document.createElement('span');
+    span.textContent = option.helper;
+
+    button.append(strong, span);
+    container.appendChild(button);
+  }
+}
+
+export function createSimpleModal({ titleText, bodyNodes = [], actionButtons = [] }) {
+  const modal = document.createElement('div');
+  modal.className = 'modal';
+
+  const content = document.createElement('div');
+  content.className = 'modal-content';
+
+  if (titleText) {
+    const title = document.createElement('h2');
+    title.textContent = titleText;
+    content.appendChild(title);
+  }
+
+  for (const node of bodyNodes) {
+    if (node) content.appendChild(node);
+  }
+
+  for (const button of actionButtons) {
+    if (button) content.appendChild(button);
+  }
+
+  modal.appendChild(content);
+  return modal;
+}
+
+export function renderTxHistoryTableBody(tbody, txs) {
+  clearNode(tbody);
+
+  if (!Array.isArray(txs) || txs.length === 0) {
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.colSpan = 5;
+    td.className = 'text-gray';
+    td.textContent = 'No transactions found.';
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+    return;
+  }
+
+  for (const tx of txs) {
+    const tr = document.createElement('tr');
+    for (const value of [tx.date, tx.type, tx.amount, tx.token, tx.status]) {
+      const td = document.createElement('td');
+      td.textContent = String(value ?? '');
+      tr.appendChild(td);
+    }
+    tbody.appendChild(tr);
+  }
+}
+
+export function renderRewardList(list, rewards, currentProgress) {
+  clearNode(list);
+  for (const reward of rewards) {
+    const li = document.createElement('li');
+    const unlocked = currentProgress >= reward.threshold;
+    li.className = unlocked ? 'unlocked' : 'locked';
+
+    const icon = document.createElement('span');
+    icon.className = 'reward-icon';
+    icon.textContent = unlocked ? '✅' : '🔒';
+
+    li.append(icon, document.createTextNode(` $${reward.threshold}+: ${reward.reward}`));
+    list.appendChild(li);
+  }
+}
+
+export function renderAchievements(list, achievements) {
+  clearNode(list);
+  for (const achievement of achievements) {
+    const li = document.createElement('li');
+    li.className = `achievement ${achievement.unlocked ? 'unlocked' : 'locked'}`;
+
+    const icon = document.createElement('div');
+    icon.className = 'achievement-icon';
+    icon.textContent = achievement.unlocked ? '🏆' : '🔒';
+
+    const info = document.createElement('div');
+    info.className = 'achievement-info';
+    const heading = document.createElement('h4');
+    heading.textContent = achievement.name;
+    const description = document.createElement('p');
+    description.textContent = achievement.description;
+    info.append(heading, description);
+
+    li.append(icon, info);
+    list.appendChild(li);
+  }
+}
+
+export function createTradeNotification(amount) {
+  const notification = document.createElement('div');
+  notification.className = 'trade-notification';
+  notification.textContent = `💰 +$${Number(amount).toFixed(2)} volume!`;
+  return notification;
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -1035,7 +1035,7 @@
     <!-- Onboarding Tour Disabled - CSP Compliance -->
     <!-- New Features Scripts -->
     <script src="dashboard-starfield.js?v=1.4.2" defer></script>
+    <script type="module" src="dashboard-dom-overrides.js"></script>
     </body>
 
 </html>
-


### PR DESCRIPTION
This begins the DOM-hardening pass for the actual live dashboard runtime loaded by `dashboard.html`.

Included in this PR:
- adds `dashboard-safe-renderers.js`
- adds `dashboard-dom-overrides.js`
- updates `dashboard.html` to load the override module

Initial overrides focus on the highest-risk live dashboard sinks:
- wallet chooser modal rendering from `dashboard-main.js`
- wallet chooser options rendering from `dashboard-main.js`
- transaction history row rendering from `dashboard.js`
- trading rewards list rendering from `dashboard.js`
- achievements list rendering from `dashboard.js`
- basic safer modal creation path for common dashboard widget modals

This follows the same low-risk pattern used for the wallet and index-page hardening passes: add safe helpers first, activate with a module hook, then continue incrementally on remaining sinks.