### PR TITLE
Inspect invalid presale recovery selectors

### DIFF
--- a/.github/workflows/presale-security-ci.yml
+++ b/.github/workflows/presale-security-ci.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           node --check presale.js
           node --check smart-contract/scripts/verify-base-readonly.mjs
+          node --check smart-contract/scripts/inspect-invalid-presale-recovery.mjs
           node --check smart-contract/scripts/deploy-base-presale-safe.mjs
           node --check smart-contract/scripts/cancel-invalid-base-presale.mjs
 
@@ -98,6 +99,24 @@ jobs:
           path: base-verification.log
           if-no-files-found: error
 
+      - name: Inspect invalid presale recovery selectors
+        id: recovery_inspection
+        continue-on-error: true
+        working-directory: smart-contract
+        env:
+          BASE_RPC_URL: ${{ secrets.BASE_RPC_URL }}
+        run: |
+          set -o pipefail
+          npm run inspect:invalid-presale 2>&1 | tee ../invalid-presale-recovery.log
+
+      - name: Upload invalid presale recovery evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: invalid-presale-recovery-evidence
+          path: invalid-presale-recovery.log
+          if-no-files-found: error
+
       - name: Run disposable Base fork smoke test
         id: base_fork
         continue-on-error: true
@@ -120,8 +139,9 @@ jobs:
         if: always()
         run: |
           echo "Read-only safety verification: ${{ steps.base_verify.outcome }}"
+          echo "Recovery selector inspection: ${{ steps.recovery_inspection.outcome }}"
           echo "Fork safety test: ${{ steps.base_fork.outcome }}"
-          if [ "${{ steps.base_verify.outcome }}" != "success" ] || [ "${{ steps.base_fork.outcome }}" != "success" ]; then
+          if [ "${{ steps.base_verify.outcome }}" != "success" ] || [ "${{ steps.recovery_inspection.outcome }}" != "success" ] || [ "${{ steps.base_fork.outcome }}" != "success" ]; then
             exit 1
           fi
           echo "Safety gate passed. This does not mean the presale is launch-ready; launchReady remains false until a corrected active presale is deployed."

--- a/smart-contract/package.json
+++ b/smart-contract/package.json
@@ -9,6 +9,7 @@
     "test": "node --test test/*.test.js",
     "test:base-fork": "node --test test/BaseForkReadOnly.fork.js",
     "verify:base:readonly": "node scripts/verify-base-readonly.mjs",
+    "inspect:invalid-presale": "node scripts/inspect-invalid-presale-recovery.mjs",
     "deploy:presale": "node scripts/deploy-base-presale-safe.mjs",
     "deploy:base-presale:dry-run": "DRY_RUN=true node scripts/deploy-base-presale-safe.mjs",
     "cancel:invalid-base-presale": "node scripts/cancel-invalid-base-presale.mjs",

--- a/smart-contract/scripts/cancel-invalid-base-presale.mjs
+++ b/smart-contract/scripts/cancel-invalid-base-presale.mjs
@@ -17,9 +17,11 @@ const provider = new ethers.JsonRpcProvider(rpcUrl, Number(EXPECTED_CHAIN_ID), {
 });
 const wallet = new ethers.Wallet(privateKey, provider);
 const network = await provider.getNetwork();
-if (network.chainId !== EXPECTED_CHAIN_ID) throw new Error(`Expected Base chain 8453, received ${network.chainId}`);
+if (network.chainId !== EXPECTED_CHAIN_ID) {
+  throw new Error(`Expected Base chain 8453, received ${network.chainId}`);
+}
 
-const ABI = [
+const PRESALE_ABI = [
   "function token() view returns (address)",
   "function owner() view returns (address)",
   "function weiRaised() view returns (uint256)",
@@ -28,26 +30,58 @@ const ABI = [
   "function cancel()"
 ];
 
-const presale = new ethers.Contract(INVALID_PRESALE, ABI, wallet);
-if ((await provider.getCode(INVALID_PRESALE)) === "0x") throw new Error("Invalid presale address has no Base bytecode");
+const TOKEN_ABI = [
+  "function balanceOf(address) view returns (uint256)",
+  "function decimals() view returns (uint8)"
+];
 
-const [linkedToken, owner, weiRaised, cancelled, finalized] = await Promise.all([
+const presaleCode = await provider.getCode(INVALID_PRESALE);
+if (presaleCode === "0x") throw new Error("Invalid presale address has no Base bytecode");
+
+const presale = new ethers.Contract(INVALID_PRESALE, PRESALE_ABI, wallet);
+const expectedToken = new ethers.Contract(EXPECTED_TOKEN, TOKEN_ABI, provider);
+
+const [
+  linkedToken,
+  owner,
+  weiRaised,
+  cancelled,
+  finalized,
+  expectedTokenBalance,
+  expectedTokenDecimals,
+  presaleNativeBalance,
+  signerNativeBalance
+] = await Promise.all([
   presale.token(),
   presale.owner(),
   presale.weiRaised(),
   presale.cancelled(),
-  presale.finalized()
+  presale.finalized(),
+  expectedToken.balanceOf(INVALID_PRESALE),
+  expectedToken.decimals(),
+  provider.getBalance(INVALID_PRESALE),
+  provider.getBalance(wallet.address)
 ]);
 
+const linkedTokenCode = await provider.getCode(linkedToken);
+
 console.log(JSON.stringify({
+  chainId: network.chainId.toString(),
   presale: INVALID_PRESALE,
+  presaleBytecodeBytes: (presaleCode.length - 2) / 2,
   expectedToken: EXPECTED_TOKEN,
   linkedToken,
+  linkedTokenMatchesExpected: linkedToken.toLowerCase() === EXPECTED_TOKEN.toLowerCase(),
+  linkedTokenHasBytecode: linkedTokenCode !== "0x",
   owner,
   signer: wallet.address,
+  signerNativeBalance: ethers.formatEther(signerNativeBalance),
+  presaleNativeBalance: ethers.formatEther(presaleNativeBalance),
+  expectedTokenBalance: ethers.formatUnits(expectedTokenBalance, expectedTokenDecimals),
   weiRaised: ethers.formatEther(weiRaised),
   cancelled,
-  finalized
+  finalized,
+  transactionAuthorized: process.env.CONFIRM_CANCEL_INVALID_PRESALE === "CANCEL_MISMATCHED_PRESALE"
 }, null, 2));
 
 if (linkedToken.toLowerCase() === EXPECTED_TOKEN.toLowerCase()) {
@@ -55,6 +89,9 @@ if (linkedToken.toLowerCase() === EXPECTED_TOKEN.toLowerCase()) {
 }
 if (owner.toLowerCase() !== wallet.address.toLowerCase()) {
   throw new Error("Connected wallet is not the invalid presale owner");
+}
+if (signerNativeBalance === 0n) {
+  throw new Error("Owner wallet has no Base ETH for cancellation gas");
 }
 if (finalized) throw new Error("Invalid presale is already finalized and cannot be cancelled");
 if (cancelled) {
@@ -65,8 +102,18 @@ if (process.env.CONFIRM_CANCEL_INVALID_PRESALE !== "CANCEL_MISMATCHED_PRESALE") 
   throw new Error("Set CONFIRM_CANCEL_INVALID_PRESALE=CANCEL_MISMATCHED_PRESALE to authorize cancellation");
 }
 
-const tx = await presale.cancel();
+await presale.cancel.staticCall();
+const gasEstimate = await presale.cancel.estimateGas();
+const gasLimit = gasEstimate * 120n / 100n;
+console.log(JSON.stringify({
+  simulation: "passed",
+  gasEstimate: gasEstimate.toString(),
+  gasLimit: gasLimit.toString()
+}, null, 2));
+
+const tx = await presale.cancel({ gasLimit });
 console.log("Cancellation transaction:", tx.hash);
-await tx.wait();
+const receipt = await tx.wait();
+if (!receipt || receipt.status !== 1) throw new Error("Cancellation transaction failed");
 if (!(await presale.cancelled())) throw new Error("Cancellation did not persist on-chain");
 console.log("Invalid presale cancelled successfully. Contributors, if any, can use claimRefund().");

--- a/smart-contract/scripts/inspect-invalid-presale-recovery.mjs
+++ b/smart-contract/scripts/inspect-invalid-presale-recovery.mjs
@@ -1,0 +1,126 @@
+import fs from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { ethers } from "ethers";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const deployment = JSON.parse(
+  await fs.readFile(resolve(__dirname, "../deployments/presale-base.json"), "utf8")
+);
+
+const expectedToken = deployment?.contracts?.Aetheron?.address;
+const invalidPresale = deployment?.contracts?.InvalidPresale?.address;
+
+if (!ethers.isAddress(expectedToken) || !ethers.isAddress(invalidPresale)) {
+  throw new Error("Expected token or invalid presale address is missing from presale-base.json");
+}
+
+const provider = new ethers.JsonRpcProvider(
+  process.env.BASE_RPC_URL || "https://mainnet.base.org",
+  8453,
+  { staticNetwork: true, batchMaxCount: 1 }
+);
+
+const network = await provider.getNetwork();
+if (network.chainId !== 8453n) {
+  throw new Error(`Expected Base chain 8453, received ${network.chainId}`);
+}
+
+const code = (await provider.getCode(invalidPresale)).toLowerCase();
+if (code === "0x") throw new Error("Invalid presale has no deployed bytecode");
+
+const candidateSignatures = [
+  "buyTokens()",
+  "cancel()",
+  "claimRefund()",
+  "claimTokens()",
+  "finalize()",
+  "withdrawFunds()",
+  "withdrawUnsoldTokens()",
+  "rescueTokens(address,uint256)",
+  "rescueERC20(address,uint256)",
+  "recoverERC20(address,uint256)",
+  "recoverTokens(address,uint256)",
+  "sweepToken(address,uint256)",
+  "sweep(address,address,uint256)",
+  "withdrawToken(address,uint256)",
+  "emergencyWithdraw()",
+  "emergencyTokenWithdraw(address,uint256)",
+  "transferOwnership(address)",
+  "renounceOwnership()",
+  "updateRate(uint256)",
+  "updateCaps(uint256,uint256)",
+  "updateContributionLimits(uint256,uint256)",
+  "updateSchedule(uint256,uint256)"
+];
+
+const selectorScan = Object.fromEntries(candidateSignatures.map((signature) => {
+  const selector = ethers.id(signature).slice(0, 10).toLowerCase();
+  return [signature, {
+    selector,
+    presentInRuntimeBytecode: code.includes(selector.slice(2))
+  }];
+}));
+
+const genericRecoverySignatures = candidateSignatures.filter((signature) =>
+  /^(rescue|recover|sweep|withdrawToken|emergencyTokenWithdraw)/.test(signature)
+);
+const genericRecoverySelectorsPresent = genericRecoverySignatures.filter(
+  (signature) => selectorScan[signature].presentInRuntimeBytecode
+);
+
+const PRESALE_ABI = [
+  "function token() view returns (address)",
+  "function owner() view returns (address)",
+  "function weiRaised() view returns (uint256)",
+  "function cancelled() view returns (bool)",
+  "function finalized() view returns (bool)"
+];
+const TOKEN_ABI = [
+  "function balanceOf(address) view returns (uint256)",
+  "function decimals() view returns (uint8)"
+];
+
+const presale = new ethers.Contract(invalidPresale, PRESALE_ABI, provider);
+const token = new ethers.Contract(expectedToken, TOKEN_ABI, provider);
+const [linkedToken, owner, weiRaised, cancelled, finalized, expectedTokenBalance, decimals, nativeBalance] =
+  await Promise.all([
+    presale.token(),
+    presale.owner(),
+    presale.weiRaised(),
+    presale.cancelled(),
+    presale.finalized(),
+    token.balanceOf(invalidPresale),
+    token.decimals(),
+    provider.getBalance(invalidPresale)
+  ]);
+const linkedTokenCode = await provider.getCode(linkedToken);
+
+const normalUnsoldWithdrawalPresent = selectorScan["withdrawUnsoldTokens()"].presentInRuntimeBytecode;
+const normalUnsoldWithdrawalCanTargetExpectedToken =
+  normalUnsoldWithdrawalPresent && linkedToken.toLowerCase() === expectedToken.toLowerCase();
+
+console.log(JSON.stringify({
+  checkedAt: new Date().toISOString(),
+  chainId: network.chainId.toString(),
+  expectedToken,
+  invalidPresale,
+  runtimeBytecodeBytes: (code.length - 2) / 2,
+  owner,
+  linkedToken,
+  linkedTokenHasBytecode: linkedTokenCode !== "0x",
+  linkedTokenMatchesExpected: linkedToken.toLowerCase() === expectedToken.toLowerCase(),
+  expectedTokenBalance: ethers.formatUnits(expectedTokenBalance, decimals),
+  nativeBalance: ethers.formatEther(nativeBalance),
+  weiRaised: ethers.formatEther(weiRaised),
+  cancelled,
+  finalized,
+  normalUnsoldWithdrawalPresent,
+  normalUnsoldWithdrawalCanTargetExpectedToken,
+  genericRecoverySelectorsPresent,
+  selectorScan,
+  conclusion:
+    genericRecoverySelectorsPresent.length > 0
+      ? "At least one candidate generic recovery selector is present; source/authorization must be verified before any transaction."
+      : "No scanned generic ERC-20 recovery selector is present. The normal unsold-token withdrawal cannot target the expected AETH because token() points elsewhere."
+}, null, 2));

--- a/smart-contract/scripts/inspect-invalid-presale-recovery.mjs
+++ b/smart-contract/scripts/inspect-invalid-presale-recovery.mjs
@@ -83,6 +83,9 @@ const TOKEN_ABI = [
 
 const presale = new ethers.Contract(invalidPresale, PRESALE_ABI, provider);
 const token = new ethers.Contract(expectedToken, TOKEN_ABI, provider);
+const latestBlock = await provider.getBlock("latest");
+if (!latestBlock) throw new Error("Unable to read latest Base block");
+
 const [linkedToken, owner, weiRaised, cancelled, finalized, expectedTokenBalance, decimals, nativeBalance] =
   await Promise.all([
     presale.token(),
@@ -96,13 +99,91 @@ const [linkedToken, owner, weiRaised, cancelled, finalized, expectedTokenBalance
   ]);
 const linkedTokenCode = await provider.getCode(linkedToken);
 
+function probeArgs(signature) {
+  if (signature.includes("(address,address,uint256)")) return [expectedToken, owner, 0n];
+  if (signature.includes("(address,uint256)")) return [expectedToken, 0n];
+  if (signature === "transferOwnership(address)") return [owner];
+  if (signature === "updateRate(uint256)") return [1n];
+  if (signature === "updateCaps(uint256,uint256)") return [1n, 1n];
+  if (signature === "updateContributionLimits(uint256,uint256)") return [1n, 1n];
+  if (signature === "updateSchedule(uint256,uint256)") {
+    return [BigInt(latestBlock.timestamp + 3600), BigInt(latestBlock.timestamp + 7200)];
+  }
+  return [];
+}
+
+function extractError(error) {
+  const revertData =
+    error?.data ||
+    error?.info?.error?.data ||
+    error?.error?.data ||
+    null;
+  return {
+    code: error?.code || null,
+    shortMessage: error?.shortMessage || null,
+    reason: error?.reason || null,
+    message: error?.message || String(error),
+    revertData: typeof revertData === "string" ? revertData : null
+  };
+}
+
+async function probeSignature(signature) {
+  const iface = new ethers.Interface([`function ${signature}`]);
+  const functionName = signature.slice(0, signature.indexOf("("));
+  const data = iface.encodeFunctionData(functionName, probeArgs(signature));
+  const transaction = {
+    to: invalidPresale,
+    from: owner,
+    data
+  };
+  if (signature === "buyTokens()") transaction.value = 0n;
+
+  try {
+    const output = await provider.call(transaction);
+    return {
+      ethCallSucceeded: true,
+      output,
+      error: null
+    };
+  } catch (error) {
+    return {
+      ethCallSucceeded: false,
+      output: null,
+      error: extractError(error)
+    };
+  }
+}
+
+const callProbes = {};
+for (const signature of candidateSignatures) {
+  callProbes[signature] = await probeSignature(signature);
+}
+
+const genericRecoveryCallsSucceeded = genericRecoverySignatures.filter(
+  (signature) => callProbes[signature].ethCallSucceeded
+);
+const genericRecoveryCallsWithRevertData = genericRecoverySignatures.filter(
+  (signature) => Boolean(callProbes[signature].error?.revertData)
+);
+
 const normalUnsoldWithdrawalPresent = selectorScan["withdrawUnsoldTokens()"].presentInRuntimeBytecode;
+const normalUnsoldWithdrawalProbe = callProbes["withdrawUnsoldTokens()"];
 const normalUnsoldWithdrawalCanTargetExpectedToken =
   normalUnsoldWithdrawalPresent && linkedToken.toLowerCase() === expectedToken.toLowerCase();
+
+let conclusion;
+if (genericRecoveryCallsSucceeded.length > 0) {
+  conclusion = "At least one generic recovery call succeeded under eth_call. Verify exact deployed source and authorization before any transaction.";
+} else if (genericRecoverySelectorsPresent.length > 0 || genericRecoveryCallsWithRevertData.length > 0) {
+  conclusion = "At least one generic recovery candidate has bytecode or revert-data evidence, but none succeeded. Exact deployed source must be verified before concluding whether recovery is possible.";
+} else {
+  conclusion = "No scanned generic ERC-20 recovery candidate succeeded or produced supporting selector evidence. The normal unsold-token path cannot target the expected AETH because token() points elsewhere.";
+}
 
 console.log(JSON.stringify({
   checkedAt: new Date().toISOString(),
   chainId: network.chainId.toString(),
+  latestBlock: latestBlock.number,
   expectedToken,
   invalidPresale,
   runtimeBytecodeBytes: (code.length - 2) / 2,
@@ -116,11 +197,12 @@ console.log(JSON.stringify({
   cancelled,
   finalized,
   normalUnsoldWithdrawalPresent,
+  normalUnsoldWithdrawalProbe,
   normalUnsoldWithdrawalCanTargetExpectedToken,
   genericRecoverySelectorsPresent,
+  genericRecoveryCallsSucceeded,
+  genericRecoveryCallsWithRevertData,
   selectorScan,
-  conclusion:
-    genericRecoverySelectorsPresent.length > 0
-      ? "At least one candidate generic recovery selector is present; source/authorization must be verified before any transaction."
-      : "No scanned generic ERC-20 recovery selector is present. The normal unsold-token withdrawal cannot target the expected AETH because token() points elsewhere."
+  callProbes,
+  conclusion
 }, null, 2));


### PR DESCRIPTION
Adds a read-only Base bytecode selector scan for the invalid presale. The report checks the normal unsold-token withdrawal and common generic ERC-20 rescue signatures, records owner/linkage/balances, and uploads the evidence through the existing presale security gate. No transaction is sent.