### PR TITLE
Fix React Native 0.85 Jest preset migration

### DIFF
--- a/mobile-app/jest.config.js
+++ b/mobile-app/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  preset: 'react-native',
+  preset: '@react-native/jest-preset',
   transformIgnorePatterns: [
     'node_modules/(?!(react-native|@react-native|react-native-vector-icons|@react-navigation|@walletconnect)/)',
   ],

--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -51,7 +51,8 @@
         "jest": "^29.7.0",
         "prettier": "^3.8.1",
         "react-test-renderer": "19.2.3",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "@react-native/jest-preset": "0.85.0"
       },
       "engines": {
         "node": ">=20.19.4",
@@ -15057,6 +15058,22 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@react-native/jest-preset": {
+      "version": "0.85.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/create-cache-key-function": "^29.7.0",
+        "@react-native/js-polyfills": "0.85.0",
+        "babel-jest": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "react": "19.2.3",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "engines": {
+        "node": ">=20.19.4"
       }
     }
   }

--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -15075,6 +15075,29 @@
       "engines": {
         "node": ">=20.19.4"
       }
+    },
+    "node_modules/@jest/create-cache-key-function": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
+      "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@react-native/jest-preset/node_modules/@react-native/js-polyfills": {
+      "version": "0.85.0",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.85.0.tgz",
+      "integrity": "sha512-h2nfIqNEA72Ebdcq5scJg1kyZ01B9xI+NJ2AA8ZpGN8SbxOBNAiZtWEqxzAUe6v5Iu7LE3+1WFBWcMQGtT4zLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "dev": true
     }
   }
 }

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -57,7 +57,8 @@
     "jest": "^29.7.0",
     "prettier": "^3.8.1",
     "react-test-renderer": "19.2.3",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "@react-native/jest-preset": "0.85.0"
   },
   "overrides": {
     "websocket-driver": "^0.7.5"


### PR DESCRIPTION
## Summary
- add `@react-native/jest-preset` at the React Native 0.85.0 version
- point `mobile-app/jest.config.js` to the standalone preset
- update the mobile lockfile for reproducible `npm ci`

## Root cause
React Native 0.85 removed its bundled Jest preset. The previous `preset: 'react-native'` now throws during Jest configuration normalization.

## Verification
The existing Mobile Dependency Security Gate will run `npm ci`, dependency audits, and the mobile Jest suite on this draft PR.