### PR TITLE
Add live DexScreener market data to aetrs.com

### DIFF
--- a/charts.js
+++ b/charts.js
@@ -1,59 +1,95 @@
-// Charts.js with added real-time market widget
-console.log('Charts.js loading...');
+// Live DexScreener market widget for the AETH Polygon pair
+const DEXSCREENER_PAIR_URL =
+  'https://dexscreener.com/polygon/0xd57c5E33ebDC1b565F99d06809debbf86142705D';
+const DEXSCREENER_API_URL =
+  'https://api.dexscreener.com/latest/dex/pairs/polygon/0xd57c5E33ebDC1b565F99d06809debbf86142705D';
 
-let priceChart=null,volumeChart=null,stakingChart=null,tvlChart=null;
+function formatUsd(value, options = {}) {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return '--';
 
-function injectDexWidget(){
-  if(document.getElementById('aethDexWidget')) return;
-  const container=document.querySelector('.container');
-  if(!container) return;
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: options.maximumFractionDigits ?? 2,
+    notation: options.compact ? 'compact' : 'standard'
+  }).format(amount);
+}
 
-  const widget=document.createElement('div');
-  widget.id='aethDexWidget';
-  widget.style.cssText='margin:20px 0;padding:18px;border-radius:16px;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1)';
+function injectDexWidget() {
+  if (document.getElementById('aethDexWidget')) return;
 
-  widget.innerHTML=`
-    <h2 style="margin-bottom:10px">Live Market</h2>
+  const container = document.querySelector('.container');
+  if (!container) return;
+
+  const widget = document.createElement('section');
+  widget.id = 'aethDexWidget';
+  widget.setAttribute('aria-labelledby', 'dexWidgetTitle');
+  widget.style.cssText =
+    'margin:20px 0;padding:18px;border-radius:16px;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1)';
+
+  widget.innerHTML = `
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-bottom:12px">
+      <div>
+        <h2 id="dexWidgetTitle" style="margin:0 0 4px">Live AETH Market</h2>
+        <div id="dexStatus" role="status" aria-live="polite" style="font-size:.85rem;opacity:.75">Loading DexScreener data…</div>
+      </div>
+      <a href="${DEXSCREENER_PAIR_URL}" target="_blank" rel="noopener noreferrer" class="btn btn-outline"
+        aria-label="View the AETH Polygon market on DexScreener">
+        <i class="fas fa-chart-line" aria-hidden="true"></i> View on DexScreener
+      </a>
+    </div>
     <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:10px">
       <div>Price<br><strong id="dexPrice">--</strong></div>
       <div>Liquidity<br><strong id="dexLiquidity">--</strong></div>
       <div>24h Volume<br><strong id="dexVolume">--</strong></div>
-      <div>Buys/Sells<br><strong id="dexTx">--</strong></div>
+      <div>24h Buys / Sells<br><strong id="dexTx">--</strong></div>
     </div>
   `;
 
-  container.insertBefore(widget,container.children[1]);
+  container.insertBefore(widget, container.children[1] || null);
 }
 
-async function updateDexWidget(){
-  try{
-    const res=await fetch('https://api.dexscreener.com/latest/dex/pairs/polygon/0xd57c5E33ebDC1b565F99d06809debbf86142705D');
-    const data=await res.json();
-    const p=data.pair;
-    if(!p) return;
+async function updateDexWidget() {
+  const status = document.getElementById('dexStatus');
 
-    document.getElementById('dexPrice').textContent='$'+Number(p.priceUsd).toFixed(8);
-    document.getElementById('dexLiquidity').textContent='$'+Math.round(p.liquidity.usd);
-    document.getElementById('dexVolume').textContent='$'+Math.round(p.volume.h24);
-    document.getElementById('dexTx').textContent=p.txns.h24.buys+'/'+p.txns.h24.sells;
-  }catch(e){console.error(e)}
+  try {
+    const response = await fetch(DEXSCREENER_API_URL);
+    if (!response.ok) throw new Error(`DexScreener request failed (${response.status})`);
+
+    const data = await response.json();
+    const pair = data.pairs?.[0];
+    if (!pair) throw new Error('DexScreener returned no matching pair');
+
+    document.getElementById('dexPrice').textContent = formatUsd(pair.priceUsd, {
+      maximumFractionDigits: 10
+    });
+    document.getElementById('dexLiquidity').textContent = formatUsd(pair.liquidity?.usd, {
+      compact: true
+    });
+    document.getElementById('dexVolume').textContent = formatUsd(pair.volume?.h24, {
+      compact: true
+    });
+    document.getElementById('dexTx').textContent =
+      `${pair.txns?.h24?.buys ?? '--'} / ${pair.txns?.h24?.sells ?? '--'}`;
+
+    if (status) status.textContent = 'Live data · refreshes every 60 seconds';
+  } catch (error) {
+    console.error('Unable to refresh DexScreener market data:', error);
+    if (status) status.textContent = 'Live data is temporarily unavailable. Open DexScreener for the latest market.';
+  }
 }
 
-// existing chart code remains unchanged below
-
-const chartData={timestamps:[],prices:[],volumes:[],tvl:[],stakingMetrics:{totalStaked:[],rewardBalance:[],stakingPercentage:[]}};
-
-function initializeCharts(){
+function initializeCharts() {
   injectDexWidget();
   updateDexWidget();
-  setInterval(updateDexWidget,30000);
-  console.log('Charts + Dex widget initialized');
+  window.setInterval(updateDexWidget, 60000);
 }
 
-if(document.readyState==='loading'){
-  document.addEventListener('DOMContentLoaded',initializeCharts);
-}else{
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initializeCharts, { once: true });
+} else {
   initializeCharts();
 }
 
-window.AetheronCharts={init:initializeCharts};
+window.AetheronCharts = { init: initializeCharts, refreshMarket: updateDexWidget };

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
   <script src="index.js?v=1.4.9" defer></script>
   <script src="monitor.js?v=1.4.2" defer></script>
   <script src="marketing-launch.js?v=1.4.2" defer></script>
-  <script src="shared-utils.js?v=1.4.4" defer></script>
+  <script src="shared-utils.js?v=1.4.4" defer></script>\n  <script src="charts.js?v=1.4.3" defer></script>
   <link rel="stylesheet" href="critical.css?v=1.4.3">
   <link rel="stylesheet" href="index.css?v=1.4.3">
   <link rel="preload" href="shared-styles.css?v=1.4.3" as="style">


### PR DESCRIPTION
## What changed

- loads the existing market widget on the aetrs.com homepage
- connects it to the supplied AETH Polygon pair on DexScreener
- fixes parsing for DexScreener's `pairs` response
- shows live price, liquidity, 24-hour volume, and buy/sell counts
- adds a direct, accessible link to the market page
- refreshes data every 60 seconds and provides a graceful error state

## Why

The widget existed but was not included by the homepage and expected a non-existent `pair` field, so no live market data could appear.

## Validation

- response parsing matches the documented DexScreener pair endpoint
- existing Content Security Policy already permits `api.dexscreener.com` and `dexscreener.com`
- changes are limited to `charts.js` and the homepage script include