### PR TITLE
Fix DexScreener homepage script markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,8 @@
   <script src="index.js?v=1.4.9" defer></script>
   <script src="monitor.js?v=1.4.2" defer></script>
   <script src="marketing-launch.js?v=1.4.2" defer></script>
-  <script src="shared-utils.js?v=1.4.4" defer></script>\n  <script src="charts.js?v=1.4.3" defer></script>
+  <script src="shared-utils.js?v=1.4.4" defer></script>
+  <script src="charts.js?v=1.4.3" defer></script>
   <link rel="stylesheet" href="critical.css?v=1.4.3">
   <link rel="stylesheet" href="index.css?v=1.4.3">
   <link rel="preload" href="shared-styles.css?v=1.4.3" as="style">


### PR DESCRIPTION
## What changed

Replaces the literal `\\n` text between the homepage script tags with an actual newline.

## Why

The literal escape sequence could make the HTML parser close `<head>` early, move later resources into `<body>`, and expose stray text on the page.

## Validation

The script tags now remain valid adjacent elements inside the document head.