### PR TITLE
Validate final Base presale production state

### DIFF
--- a/smart-contract/FINAL_VALIDATION_2026-07-16.md
+++ b/smart-contract/FINAL_VALIDATION_2026-07-16.md
@@ -1,0 +1,17 @@
+# Final Presale Validation — July 16, 2026
+
+This change exists to validate the exact production branch state after the presale workflow hardening.
+
+The required checks cover:
+
+- JavaScript syntax
+- exact dependency installation
+- Solidity compilation
+- contract and frontend tests
+- production-configuration invariants
+- Base bytecode and read-only state inspection
+- invalid-presale recovery selector inspection
+- disposable Base fork simulation
+- credential-readiness reporting without exposing secret values
+
+No transaction is authorized or submitted by this validation change.


### PR DESCRIPTION
Runs the complete presale validation suite against the exact current `main` state after the deployment journaling, BaseScan V2, disabled-frontend publication, and credential-readiness fixes. No transaction is authorized by this PR.