### PR TITLE
Fix broken corrected-presale workflow dispatch

### DIFF
--- a/.github/workflows/deploy-corrected-presale.yml
+++ b/.github/workflows/deploy-corrected-presale.yml
@@ -3,7 +3,7 @@ name: Deploy Corrected Base Presale
 on:
   workflow_dispatch:
     inputs:
-      dry_run:"false"
+      dry_run:
         description: "Run all preflight checks without sending transactions"
         required: true
         type: boolean
@@ -47,7 +47,7 @@ on:
         description: "For a live deployment type DEPLOY_CORRECTED_PRESALE; leave DRY_RUN for rehearsal"
         required: true
         type: string
-        default: "DEPLOY_CORRECTED_PRESALE"
+        default: "DRY_RUN"
 
 permissions:
   contents: write


### PR DESCRIPTION
Restores the valid `workflow_dispatch` input key after the accidental `dry_run:"false"` edit made the workflow YAML invalid.

- restores `dry_run:` as a boolean workflow input
- restores the safe `DRY_RUN` confirmation default
- preserves the explicit `DEPLOY_CORRECTED_PRESALE` gate for live deployment
- does not send any transaction

Current repository evidence still shows no replacement deployment address recorded.