### PR TITLE
Restore valid corrected-presale workflow input

### DIFF
--- a/.github/workflows/deploy-corrected-presale.yml
+++ b/.github/workflows/deploy-corrected-presale.yml
@@ -3,7 +3,7 @@ name: Deploy Corrected Base Presale
 on:
   workflow_dispatch:
     inputs:
-      dry_run: false
+      dry_run:
         description: "Run all preflight checks without sending transactions"
         required: true
         type: boolean


### PR DESCRIPTION
Restores the valid boolean `dry_run` workflow input after a manual edit changed the YAML key to `dry_run: false`, which prevented GitHub Actions from recognizing the workflow correctly.

- restores `dry_run:` as the input name
- preserves the safe default `true`
- preserves the explicit `DEPLOY_CORRECTED_PRESALE` live confirmation gate
- does not send a blockchain transaction

Current deployment evidence still records no replacement presale address.