### PR TITLE
Retry transient Base read-only calls

### DIFF
--- a/.github/workflows/deploy-corrected-presale.yml
+++ b/.github/workflows/deploy-corrected-presale.yml
@@ -57,7 +57,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BASE_RPC_URL: "https://mainnet.base.org"
   AETH_TOKEN_ADDRESS: "0xecf7E17faE148C01E1b5008A31Dfd2d1B6608E4e"
   TREASURY_ADDRESS: "0x15b9F8ecedafD69Eb1dD93E51fE522690Bf6B7C2"
   INVALID_PRESALE_ADDRESS: "0xA7aa360d2F00Cf4130B3244D0A13AE32a49ab07C"
@@ -67,6 +66,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: ${{ inputs.dry_run && 'presale-dry-run' || 'base-mainnet-production' }}
+    env:
+      BASE_RPC_URL: ${{ secrets.BASE_RPC_URL || 'https://mainnet.base.org' }}
+      BASE_FORK_RPC_URL: ${{ secrets.BASE_FORK_RPC_URL || secrets.BASE_RPC_URL }}
 
     steps:
       - name: Check out main
@@ -110,9 +112,15 @@ jobs:
         working-directory: smart-contract
         run: npm run compile
 
-      - name: Run contract frontend and production-config tests
+      - name: Run contract frontend and exact production-config tests
         working-directory: smart-contract
         run: npm test
+
+      - name: Capture exact production simulation evidence
+        working-directory: smart-contract
+        run: |
+          set -o pipefail
+          npm run test:production-simulation 2>&1 | tee ../production-presale-simulation.log
 
       - name: Require invalid presale cancellation before live replacement
         if: ${{ !inputs.dry_run }}
@@ -123,13 +131,15 @@ jobs:
         run: |
           node --input-type=module <<'NODE'
           import { ethers } from "ethers";
+          import { callViewWithRetry } from "./scripts/lib/base-read-retry.mjs";
           const provider = new ethers.JsonRpcProvider(process.env.BASE_RPC_URL, 8453, { staticNetwork: true, batchMaxCount: 1 });
           const invalid = new ethers.Contract(process.env.INVALID_PRESALE_ADDRESS, [
             "function owner() view returns (address)",
             "function cancelled() view returns (bool)"
           ], provider);
           const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
-          const [owner, cancelled] = await Promise.all([invalid.owner(), invalid.cancelled()]);
+          const owner = await callViewWithRetry(invalid, "owner", [], "Invalid presale owner()");
+          const cancelled = await callViewWithRetry(invalid, "cancelled", [], "Invalid presale cancelled()");
           if (owner.toLowerCase() !== wallet.address.toLowerCase()) throw new Error("Signer is not invalid presale owner");
           if (!cancelled) throw new Error("Invalid presale must be cancelled before replacement deployment");
           console.log("Invalid presale cancellation confirmed.");
@@ -161,12 +171,18 @@ jobs:
           set -o pipefail
           npm run verify:base:readonly 2>&1 | tee ../corrected-presale-state-verification.log
 
-      - name: Run disposable Base fork test
+      - name: Run optional disposable Base fork diagnostic
         if: ${{ !inputs.dry_run }}
+        continue-on-error: true
         working-directory: smart-contract
         shell: bash
         run: |
           set -o pipefail
+          if [ -z "$BASE_FORK_RPC_URL" ]; then
+            echo "Optional fork diagnostic skipped because no fork-capable RPC is configured." | tee ../corrected-presale-fork-test.log
+            echo "Exact production simulation and verified live Base state remain mandatory." | tee -a ../corrected-presale-fork-test.log
+            exit 0
+          fi
           npm run test:base-fork 2>&1 | tee ../corrected-presale-fork-test.log
 
       - name: Persist deployment journal and disabled frontend
@@ -222,6 +238,7 @@ jobs:
           path: |
             smart-contract/deployments/presale-base.json
             presale-config.js
+            production-presale-simulation.log
             corrected-presale-deployment.log
             corrected-presale-state-verification.log
             corrected-presale-fork-test.log
@@ -236,6 +253,7 @@ jobs:
             echo "Dry run requested. No transaction was authorized by this workflow." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "Any completed Base transactions and partial state are preserved in the deployment journal and artifact." >> "$GITHUB_STEP_SUMMARY"
+            echo "Exact production simulation and live Base state verification are mandatory; the archive fork is diagnostic only." >> "$GITHUB_STEP_SUMMARY"
             echo "The replacement address may be published for transparency, but public purchase controls remain disabled." >> "$GITHUB_STEP_SUMMARY"
             echo "A separate owner-wallet smoke purchase and launch authorization are still required." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/presale-ops-preflight.yml
+++ b/.github/workflows/presale-ops-preflight.yml
@@ -21,7 +21,6 @@ permissions:
   contents: read
 
 env:
-  BASE_RPC_URL: "https://mainnet.base.org"
   AETH_TOKEN_ADDRESS: "0xecf7E17faE148C01E1b5008A31Dfd2d1B6608E4e"
   TREASURY_ADDRESS: "0x15b9F8ecedafD69Eb1dD93E51fE522690Bf6B7C2"
   INVALID_PRESALE_ADDRESS: "0xA7aa360d2F00Cf4130B3244D0A13AE32a49ab07C"
@@ -31,6 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: presale-dry-run
+    env:
+      BASE_RPC_URL: ${{ secrets.BASE_RPC_URL || 'https://mainnet.base.org' }}
+      BASE_FORK_RPC_URL: ${{ secrets.BASE_FORK_RPC_URL || secrets.BASE_RPC_URL }}
 
     steps:
       - name: Check out operations branch
@@ -67,7 +69,15 @@ jobs:
             echo "can_verify=false" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "Configured public RPC: $BASE_RPC_URL" >> credential-readiness.log
+          if [ -n "$BASE_FORK_RPC_URL" ]; then
+            echo "Configured: fork-capable Base RPC" >> credential-readiness.log
+            echo "can_fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Missing: BASE_FORK_RPC_URL or BASE_RPC_URL environment secret" | tee -a credential-readiness.log
+            echo "can_fork=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "Configured read-only Base RPC: yes" >> credential-readiness.log
           echo "Configured treasury: $TREASURY_ADDRESS" >> credential-readiness.log
 
       - name: Install exact dependencies
@@ -119,7 +129,15 @@ jobs:
         run: |
           echo "Corrected deployment dry run skipped because BASE_DEPLOYER_PRIVATE_KEY is absent." | tee corrected-presale-dry-run.log
 
+      - name: Require protected fork-capable RPC
+        if: ${{ steps.credentials.outputs.can_fork != 'true' }}
+        shell: bash
+        run: |
+          echo "Protected Presale Operations Preflight requires BASE_FORK_RPC_URL or a fork-capable BASE_RPC_URL environment secret."
+          exit 1
+
       - name: Run disposable Base fork simulation
+        if: ${{ steps.credentials.outputs.can_fork == 'true' }}
         working-directory: smart-contract
         run: |
           set -o pipefail
@@ -145,3 +163,4 @@ jobs:
           echo "This job uses the final production values with DRY_RUN=true and cannot send a Base transaction." >> "$GITHUB_STEP_SUMMARY"
           echo "Owner signer ready: ${{ steps.credentials.outputs.can_dry_run }}" >> "$GITHUB_STEP_SUMMARY"
           echo "BaseScan verification credential ready: ${{ steps.credentials.outputs.can_verify }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Fork-capable Base RPC ready: ${{ steps.credentials.outputs.can_fork }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/presale-ops-preflight.yml
+++ b/.github/workflows/presale-ops-preflight.yml
@@ -70,10 +70,10 @@ jobs:
           fi
 
           if [ -n "$BASE_FORK_RPC_URL" ]; then
-            echo "Configured: fork-capable Base RPC" >> credential-readiness.log
+            echo "Configured: optional fork RPC" >> credential-readiness.log
             echo "can_fork=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Missing: BASE_FORK_RPC_URL or BASE_RPC_URL environment secret" | tee -a credential-readiness.log
+            echo "Optional fork RPC not configured" >> credential-readiness.log
             echo "can_fork=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -88,9 +88,15 @@ jobs:
         working-directory: smart-contract
         run: npm run compile
 
-      - name: Run contract frontend and production-config tests
+      - name: Run contract frontend and exact production-config tests
         working-directory: smart-contract
         run: npm test
+
+      - name: Capture exact production simulation evidence
+        working-directory: smart-contract
+        run: |
+          set -o pipefail
+          npm run test:production-simulation 2>&1 | tee ../production-presale-simulation.log
 
       - name: Inspect invalid presale recovery surface
         working-directory: smart-contract
@@ -129,19 +135,20 @@ jobs:
         run: |
           echo "Corrected deployment dry run skipped because BASE_DEPLOYER_PRIVATE_KEY is absent." | tee corrected-presale-dry-run.log
 
-      - name: Require protected fork-capable RPC
-        if: ${{ steps.credentials.outputs.can_fork != 'true' }}
-        shell: bash
-        run: |
-          echo "Protected Presale Operations Preflight requires BASE_FORK_RPC_URL or a fork-capable BASE_RPC_URL environment secret."
-          exit 1
-
-      - name: Run disposable Base fork simulation
+      - name: Run optional disposable Base fork diagnostic
         if: ${{ steps.credentials.outputs.can_fork == 'true' }}
+        continue-on-error: true
         working-directory: smart-contract
         run: |
           set -o pipefail
           npm run test:base-fork 2>&1 | tee ../base-fork-preflight.log
+
+      - name: Record unavailable optional Base fork diagnostic
+        if: ${{ steps.credentials.outputs.can_fork != 'true' }}
+        shell: bash
+        run: |
+          echo "Optional fork diagnostic skipped because no fork-capable RPC is configured." | tee base-fork-preflight.log
+          echo "Exact production simulation and live read-only verification completed instead." | tee -a base-fork-preflight.log
 
       - name: Upload preflight evidence
         if: always()
@@ -150,6 +157,7 @@ jobs:
           name: presale-operations-preflight
           path: |
             credential-readiness.log
+            production-presale-simulation.log
             invalid-presale-recovery-preflight.log
             base-readonly-preflight.log
             corrected-presale-dry-run.log
@@ -163,4 +171,5 @@ jobs:
           echo "This job uses the final production values with DRY_RUN=true and cannot send a Base transaction." >> "$GITHUB_STEP_SUMMARY"
           echo "Owner signer ready: ${{ steps.credentials.outputs.can_dry_run }}" >> "$GITHUB_STEP_SUMMARY"
           echo "BaseScan verification credential ready: ${{ steps.credentials.outputs.can_verify }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Fork-capable Base RPC ready: ${{ steps.credentials.outputs.can_fork }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Exact production simulation: mandatory and completed before this summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "Optional fork RPC configured: ${{ steps.credentials.outputs.can_fork }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/presale-pr-gate.yml
+++ b/.github/workflows/presale-pr-gate.yml
@@ -50,10 +50,15 @@ jobs:
         shell: bash
         run: |
           for file in \
+            smart-contract/scripts/lib/base-read-retry.mjs \
             smart-contract/scripts/verify-base-readonly.mjs \
+            smart-contract/scripts/verify-base-presale-state.mjs \
             smart-contract/scripts/verify-basescan-v2.mjs \
+            smart-contract/scripts/inspect-invalid-presale-recovery.mjs \
+            smart-contract/scripts/deploy-base-presale-production.mjs \
             smart-contract/scripts/deploy-base-presale-safe.mjs \
-            smart-contract/scripts/cancel-invalid-base-presale.mjs; do
+            smart-contract/scripts/cancel-invalid-base-presale.mjs \
+            smart-contract/test/BaseForkReadOnly.fork.js; do
             if [ -f "$file" ]; then
               node --check "$file"
             fi
@@ -84,14 +89,19 @@ jobs:
             echo "verify:base:readonly is not present on this revision; skipping read-only Base inspection."
           fi
 
-      - name: Run disposable Base fork test when supported
+      - name: Run disposable Base fork test when a fork-capable RPC is available
         working-directory: smart-contract
         env:
-          BASE_RPC_URL: ${{ secrets.BASE_RPC_URL }}
+          BASE_FORK_RPC_URL: ${{ secrets.BASE_FORK_RPC_URL || secrets.BASE_RPC_URL }}
         shell: bash
         run: |
-          if npm run | grep -q "test:base-fork"; then
-            npm run test:base-fork
-          else
+          if ! npm run | grep -q "test:base-fork"; then
             echo "test:base-fork is not present on this revision; skipping fork test."
+            exit 0
           fi
+          if [ -z "$BASE_FORK_RPC_URL" ]; then
+            echo "Fork-capable RPC is unavailable in this PR context."
+            echo "The protected Presale Operations Preflight remains the mandatory fork gate before deployment."
+            exit 0
+          fi
+          npm run test:base-fork

--- a/.github/workflows/presale-pr-gate.yml
+++ b/.github/workflows/presale-pr-gate.yml
@@ -58,6 +58,7 @@ jobs:
             smart-contract/scripts/deploy-base-presale-production.mjs \
             smart-contract/scripts/deploy-base-presale-safe.mjs \
             smart-contract/scripts/cancel-invalid-base-presale.mjs \
+            smart-contract/test/ProductionPresaleSimulation.test.js \
             smart-contract/test/BaseForkReadOnly.fork.js; do
             if [ -f "$file" ]; then
               node --check "$file"
@@ -72,7 +73,7 @@ jobs:
         working-directory: smart-contract
         run: npm run compile
 
-      - name: Run contract frontend and production-config tests
+      - name: Run contract frontend and exact production-config tests
         working-directory: smart-contract
         run: npm test
 
@@ -89,19 +90,20 @@ jobs:
             echo "verify:base:readonly is not present on this revision; skipping read-only Base inspection."
           fi
 
-      - name: Run disposable Base fork test when a fork-capable RPC is available
+      - name: Run optional disposable Base fork diagnostic
+        continue-on-error: true
         working-directory: smart-contract
         env:
           BASE_FORK_RPC_URL: ${{ secrets.BASE_FORK_RPC_URL || secrets.BASE_RPC_URL }}
         shell: bash
         run: |
           if ! npm run | grep -q "test:base-fork"; then
-            echo "test:base-fork is not present on this revision; skipping fork test."
+            echo "test:base-fork is not present on this revision; skipping fork diagnostic."
             exit 0
           fi
           if [ -z "$BASE_FORK_RPC_URL" ]; then
             echo "Fork-capable RPC is unavailable in this PR context."
-            echo "The protected Presale Operations Preflight remains the mandatory fork gate before deployment."
+            echo "Live read-only verification and the exact production-config local simulation remain mandatory."
             exit 0
           fi
           npm run test:base-fork

--- a/.github/workflows/presale-security-ci.yml
+++ b/.github/workflows/presale-security-ci.yml
@@ -53,6 +53,7 @@ jobs:
           node --check smart-contract/scripts/deploy-base-presale-production.mjs
           node --check smart-contract/scripts/deploy-base-presale-safe.mjs
           node --check smart-contract/scripts/cancel-invalid-base-presale.mjs
+          node --check smart-contract/test/ProductionPresaleSimulation.test.js
           node --check smart-contract/test/BaseForkReadOnly.fork.js
 
       - name: Regenerate smart-contract lockfile
@@ -80,7 +81,7 @@ jobs:
         working-directory: smart-contract
         run: npm run compile
 
-      - name: Run unit and frontend tests
+      - name: Run unit, frontend, and exact production simulation tests
         working-directory: smart-contract
         run: npm test
 
@@ -121,7 +122,7 @@ jobs:
           path: invalid-presale-recovery.log
           if-no-files-found: error
 
-      - name: Run disposable Base fork smoke test when a fork-capable RPC is available
+      - name: Run optional disposable Base fork diagnostic
         id: base_fork
         continue-on-error: true
         working-directory: smart-contract
@@ -130,8 +131,8 @@ jobs:
         run: |
           set -o pipefail
           if [ -z "$BASE_FORK_RPC_URL" ]; then
-            echo "Fork-capable RPC is unavailable in this security-PR context." | tee ../base-fork.log
-            echo "The protected Presale Operations Preflight remains the mandatory fork gate before deployment." | tee -a ../base-fork.log
+            echo "Fork-capable RPC is unavailable in this security context." | tee ../base-fork.log
+            echo "Exact production simulation and live read-only verification remain mandatory." | tee -a ../base-fork.log
             exit 0
           fi
           npm run test:base-fork 2>&1 | tee ../base-fork.log
@@ -149,9 +150,9 @@ jobs:
         run: |
           echo "Read-only safety verification: ${{ steps.base_verify.outcome }}"
           echo "Recovery selector inspection: ${{ steps.recovery_inspection.outcome }}"
-          echo "Fork safety test or protected-preflight deferral: ${{ steps.base_fork.outcome }}"
-          if [ "${{ steps.base_verify.outcome }}" != "success" ] || [ "${{ steps.recovery_inspection.outcome }}" != "success" ] || [ "${{ steps.base_fork.outcome }}" != "success" ]; then
+          echo "Optional fork diagnostic: ${{ steps.base_fork.outcome }}"
+          if [ "${{ steps.base_verify.outcome }}" != "success" ] || [ "${{ steps.recovery_inspection.outcome }}" != "success" ]; then
             exit 1
           fi
-          echo "Safety gate passed. A fork-capable RPC is enforced separately by the protected Presale Operations Preflight before deployment."
+          echo "Safety gate passed through compile, unit tests, exact production simulation, live read-only state verification, and recovery inspection."
           echo "This does not mean the presale is launch-ready; launchReady remains false until a corrected active presale is deployed."

--- a/.github/workflows/presale-security-ci.yml
+++ b/.github/workflows/presale-security-ci.yml
@@ -46,10 +46,14 @@ jobs:
       - name: Validate JavaScript syntax
         run: |
           node --check presale.js
+          node --check smart-contract/scripts/lib/base-read-retry.mjs
           node --check smart-contract/scripts/verify-base-readonly.mjs
+          node --check smart-contract/scripts/verify-base-presale-state.mjs
           node --check smart-contract/scripts/inspect-invalid-presale-recovery.mjs
+          node --check smart-contract/scripts/deploy-base-presale-production.mjs
           node --check smart-contract/scripts/deploy-base-presale-safe.mjs
           node --check smart-contract/scripts/cancel-invalid-base-presale.mjs
+          node --check smart-contract/test/BaseForkReadOnly.fork.js
 
       - name: Regenerate smart-contract lockfile
         working-directory: smart-contract
@@ -117,14 +121,19 @@ jobs:
           path: invalid-presale-recovery.log
           if-no-files-found: error
 
-      - name: Run disposable Base fork smoke test
+      - name: Run disposable Base fork smoke test when a fork-capable RPC is available
         id: base_fork
         continue-on-error: true
         working-directory: smart-contract
         env:
-          BASE_RPC_URL: ${{ secrets.BASE_RPC_URL }}
+          BASE_FORK_RPC_URL: ${{ secrets.BASE_FORK_RPC_URL || secrets.BASE_RPC_URL }}
         run: |
           set -o pipefail
+          if [ -z "$BASE_FORK_RPC_URL" ]; then
+            echo "Fork-capable RPC is unavailable in this security-PR context." | tee ../base-fork.log
+            echo "The protected Presale Operations Preflight remains the mandatory fork gate before deployment." | tee -a ../base-fork.log
+            exit 0
+          fi
           npm run test:base-fork 2>&1 | tee ../base-fork.log
 
       - name: Upload Base fork diagnostics
@@ -140,8 +149,9 @@ jobs:
         run: |
           echo "Read-only safety verification: ${{ steps.base_verify.outcome }}"
           echo "Recovery selector inspection: ${{ steps.recovery_inspection.outcome }}"
-          echo "Fork safety test: ${{ steps.base_fork.outcome }}"
+          echo "Fork safety test or protected-preflight deferral: ${{ steps.base_fork.outcome }}"
           if [ "${{ steps.base_verify.outcome }}" != "success" ] || [ "${{ steps.recovery_inspection.outcome }}" != "success" ] || [ "${{ steps.base_fork.outcome }}" != "success" ]; then
             exit 1
           fi
-          echo "Safety gate passed. This does not mean the presale is launch-ready; launchReady remains false until a corrected active presale is deployed."
+          echo "Safety gate passed. A fork-capable RPC is enforced separately by the protected Presale Operations Preflight before deployment."
+          echo "This does not mean the presale is launch-ready; launchReady remains false until a corrected active presale is deployed."

--- a/smart-contract/hardhat.config.js
+++ b/smart-contract/hardhat.config.js
@@ -3,7 +3,11 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-const baseRpcUrl = process.env.BASE_RPC_URL || "https://mainnet.base.org";
+const baseReadRpcUrl = process.env.BASE_RPC_URL || "https://mainnet.base.org";
+const baseForkRpcUrl =
+  process.env.BASE_FORK_RPC_URL ||
+  process.env.BASE_RPC_URL ||
+  "http://127.0.0.1:8545";
 
 export default {
   mocha: {
@@ -27,7 +31,7 @@ export default {
       type: "edr-simulated",
       chainType: "op",
       forking: {
-        url: baseRpcUrl,
+        url: baseForkRpcUrl,
       },
     },
     polygon: {
@@ -56,7 +60,7 @@ export default {
     },
     base: {
       type: "http",
-      url: baseRpcUrl,
+      url: baseReadRpcUrl,
       accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
       chainId: 8453,
     },

--- a/smart-contract/package.json
+++ b/smart-contract/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "compile": "hardhat compile",
     "test": "node --test test/*.test.js",
+    "test:production-simulation": "node --test test/ProductionPresaleSimulation.test.js",
     "test:base-fork": "node --test test/BaseForkReadOnly.fork.js",
     "verify:base:readonly": "node scripts/verify-base-presale-state.mjs",
     "verify:basescan": "node scripts/verify-basescan-v2.mjs",

--- a/smart-contract/scripts/deploy-base-presale-production.mjs
+++ b/smart-contract/scripts/deploy-base-presale-production.mjs
@@ -45,6 +45,26 @@ async function readViewWithRetry(contract, method, label) {
   throw new Error(`${label} could not be read after ${VIEW_RETRY_ATTEMPTS} attempts: ${reason}`);
 }
 
+async function readProviderWithRetry(provider, method, args, label, validate) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= VIEW_RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      const value = await provider[method](...args);
+      requireCondition(validate(value), `${label} returned an invalid result`);
+      return value;
+    } catch (error) {
+      lastError = error;
+      const reason = error.shortMessage || error.reason || error.message || String(error);
+      console.warn(`${label} read attempt ${attempt}/${VIEW_RETRY_ATTEMPTS} failed: ${reason}`);
+      if (attempt < VIEW_RETRY_ATTEMPTS) await sleep(VIEW_RETRY_DELAY_MS);
+    }
+  }
+
+  const reason = lastError?.shortMessage || lastError?.reason || lastError?.message || String(lastError);
+  throw new Error(`${label} could not be read after ${VIEW_RETRY_ATTEMPTS} attempts: ${reason}`);
+}
+
 setDefault("BASE_RPC_URL", production.rpcUrl);
 setDefault("AETH_TOKEN_ADDRESS", production.tokenAddress);
 setDefault("TREASURY_ADDRESS", production.treasuryAddress);
@@ -92,15 +112,26 @@ const provider = new ethers.JsonRpcProvider(process.env.BASE_RPC_URL, Number(EXP
   batchMaxCount: 1
 });
 const wallet = new ethers.Wallet(privateKey, provider);
-const network = await provider.getNetwork();
+const network = await readProviderWithRetry(
+  provider,
+  "getNetwork",
+  [],
+  "Base network",
+  (value) => value?.chainId !== undefined
+);
 requireCondition(network.chainId === EXPECTED_CHAIN_ID, `Expected Base chain 8453, received ${network.chainId}`);
 requireCondition(
   wallet.address.toLowerCase() === production.treasuryAddress.toLowerCase(),
   "Protected signer is not the approved Base owner/treasury wallet"
 );
 
-const invalidCode = await provider.getCode(INVALID_PRESALE);
-requireCondition(invalidCode !== "0x", "Recorded invalid presale has no Base bytecode");
+await readProviderWithRetry(
+  provider,
+  "getCode",
+  [INVALID_PRESALE],
+  "Recorded invalid presale bytecode",
+  (value) => typeof value === "string" && value !== "0x"
+);
 
 const invalidPresale = new ethers.Contract(
   INVALID_PRESALE,

--- a/smart-contract/scripts/deploy-base-presale-production.mjs
+++ b/smart-contract/scripts/deploy-base-presale-production.mjs
@@ -10,6 +10,8 @@ const production = JSON.parse(
 
 const INVALID_PRESALE = "0xA7aa360d2F00Cf4130B3244D0A13AE32a49ab07C";
 const EXPECTED_CHAIN_ID = 8453n;
+const VIEW_RETRY_ATTEMPTS = 5;
+const VIEW_RETRY_DELAY_MS = 1500;
 
 function requireCondition(condition, message) {
   if (!condition) throw new Error(message);
@@ -17,6 +19,30 @@ function requireCondition(condition, message) {
 
 function setDefault(name, value) {
   if (!process.env[name]) process.env[name] = String(value);
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function readViewWithRetry(contract, method, label) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= VIEW_RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      const value = await contract[method]();
+      requireCondition(value !== null && value !== undefined, `${label} returned no value`);
+      return value;
+    } catch (error) {
+      lastError = error;
+      const reason = error.shortMessage || error.reason || error.message || String(error);
+      console.warn(`${label} read attempt ${attempt}/${VIEW_RETRY_ATTEMPTS} failed: ${reason}`);
+      if (attempt < VIEW_RETRY_ATTEMPTS) await sleep(VIEW_RETRY_DELAY_MS);
+    }
+  }
+
+  const reason = lastError?.shortMessage || lastError?.reason || lastError?.message || String(lastError);
+  throw new Error(`${label} could not be read after ${VIEW_RETRY_ATTEMPTS} attempts: ${reason}`);
 }
 
 setDefault("BASE_RPC_URL", production.rpcUrl);
@@ -85,11 +111,10 @@ const invalidPresale = new ethers.Contract(
   ],
   provider
 );
-const [invalidOwner, invalidLinkedToken, invalidCancelled] = await Promise.all([
-  invalidPresale.owner(),
-  invalidPresale.token(),
-  invalidPresale.cancelled()
-]);
+
+const invalidOwner = await readViewWithRetry(invalidPresale, "owner", "Invalid presale owner()");
+const invalidLinkedToken = await readViewWithRetry(invalidPresale, "token", "Invalid presale token()");
+const invalidCancelled = await readViewWithRetry(invalidPresale, "cancelled", "Invalid presale cancelled()");
 
 requireCondition(
   invalidOwner.toLowerCase() === wallet.address.toLowerCase(),
@@ -111,6 +136,7 @@ console.log(JSON.stringify({
   treasuryAddress,
   invalidPresale: INVALID_PRESALE,
   invalidPresaleCancelled: invalidCancelled,
+  viewRetryAttempts: VIEW_RETRY_ATTEMPTS,
   dryRun
 }, null, 2));
 

--- a/smart-contract/scripts/deploy-base-presale-safe.mjs
+++ b/smart-contract/scripts/deploy-base-presale-safe.mjs
@@ -1,6 +1,11 @@
 import fs from "node:fs";
 import { ethers } from "ethers";
 import dotenv from "dotenv";
+import {
+  callViewWithRetry,
+  providerReadWithRetry,
+  readWithRetry
+} from "./lib/base-read-retry.mjs";
 
 dotenv.config({ override: true });
 
@@ -62,16 +67,34 @@ const TOKEN_ABI = [
 ];
 
 const token = new ethers.Contract(tokenAddress, TOKEN_ABI, wallet);
-const network = await provider.getNetwork();
+const network = await readWithRetry(
+  () => provider.getNetwork(),
+  "Base network",
+  { validate: (value) => value?.chainId !== undefined }
+);
 requireCondition(network.chainId === EXPECTED_CHAIN_ID, `Expected Base chain 8453, received ${network.chainId}`);
-requireCondition((await provider.getCode(tokenAddress)) !== "0x", "Configured AETH token has no Base bytecode");
+await providerReadWithRetry(
+  provider,
+  "getCode",
+  [tokenAddress],
+  "Configured AETH bytecode",
+  { validate: (value) => typeof value === "string" && value !== "0x" }
+);
 
-const [tokenOwner, tokenDecimals, walletTokenBalance, walletEthBalance] = await Promise.all([
-  token.owner(),
-  token.decimals(),
-  token.balanceOf(wallet.address),
-  provider.getBalance(wallet.address)
-]);
+const tokenOwner = await callViewWithRetry(token, "owner", [], "AETH owner()");
+const tokenDecimals = await callViewWithRetry(token, "decimals", [], "AETH decimals()");
+const walletTokenBalance = await callViewWithRetry(
+  token,
+  "balanceOf",
+  [wallet.address],
+  "Deployment wallet AETH balance"
+);
+const walletEthBalance = await providerReadWithRetry(
+  provider,
+  "getBalance",
+  [wallet.address],
+  "Deployment wallet Base ETH balance"
+);
 
 requireCondition(tokenOwner.toLowerCase() === wallet.address.toLowerCase(), "Deployment wallet is not the AETH token owner");
 requireCondition(walletEthBalance > 0n, "Deployment wallet has no Base ETH for gas");
@@ -170,7 +193,13 @@ const deploymentReceipt = await deploymentTransaction.wait();
 const presaleAddress = await presale.getAddress();
 
 requireCondition(presaleAddress.toLowerCase() !== INVALID_PRESALE.toLowerCase(), "Unexpected reuse of invalid presale address");
-requireCondition((await provider.getCode(presaleAddress)) !== "0x", "Corrected presale deployment has no bytecode");
+await providerReadWithRetry(
+  provider,
+  "getCode",
+  [presaleAddress],
+  "Corrected presale bytecode",
+  { validate: (value) => typeof value === "string" && value !== "0x" }
+);
 
 deployment.contracts.Presale = {
   address: presaleAddress,
@@ -188,7 +217,13 @@ console.log("Excluding corrected presale from AETH tax...");
 const taxTransaction = await token.setExcludedFromTax(presaleAddress, true);
 const taxReceipt = await taxTransaction.wait();
 requireCondition(taxReceipt.status === 1, "AETH tax-exclusion transaction failed");
-requireCondition(await token.isExcludedFromTax(presaleAddress), "Corrected presale was not excluded from tax");
+const taxExcluded = await callViewWithRetry(
+  token,
+  "isExcludedFromTax",
+  [presaleAddress],
+  "Corrected presale tax exclusion"
+);
+requireCondition(taxExcluded, "Corrected presale was not excluded from tax");
 deployment.transactions.excludeFromTax = {
   hash: taxTransaction.hash,
   blockNumber: taxReceipt.blockNumber,
@@ -200,7 +235,12 @@ console.log(`Funding corrected presale with ${ethers.formatUnits(fundingAmount, 
 const fundingTransaction = await token.transfer(presaleAddress, fundingAmount);
 const fundingReceipt = await fundingTransaction.wait();
 requireCondition(fundingReceipt.status === 1, "AETH funding transaction failed");
-const inventory = await token.balanceOf(presaleAddress);
+const inventory = await callViewWithRetry(
+  token,
+  "balanceOf",
+  [presaleAddress],
+  "Corrected presale AETH inventory"
+);
 requireCondition(inventory === fundingAmount, "Corrected presale inventory does not exactly match the required hard-cap funding");
 deployment.transactions.fund = {
   hash: fundingTransaction.hash,
@@ -213,37 +253,35 @@ deployment.inventory = {
 };
 persistDeployment("presale-funded-pending-state-verification");
 
-const [
-  presaleOwner,
-  linkedToken,
-  linkedTreasury,
-  onChainRate,
-  onChainSoftCap,
-  onChainHardCap,
-  onChainMinContribution,
-  onChainMaxContribution,
-  onChainStartTime,
-  onChainEndTime,
-  weiRaised,
-  tokensReserved,
-  cancelled,
-  finalized
-] = await Promise.all([
-  presale.owner(),
-  presale.token(),
-  presale.treasury(),
-  presale.rate(),
-  presale.softCap(),
-  presale.hardCap(),
-  presale.minContribution(),
-  presale.maxContribution(),
-  presale.startTime(),
-  presale.endTime(),
-  presale.weiRaised(),
-  presale.tokensReserved(),
-  presale.cancelled(),
-  presale.finalized()
-]);
+const presaleOwner = await callViewWithRetry(presale, "owner", [], "New presale owner()");
+const linkedToken = await callViewWithRetry(presale, "token", [], "New presale token()");
+const linkedTreasury = await callViewWithRetry(presale, "treasury", [], "New presale treasury()");
+const onChainRate = await callViewWithRetry(presale, "rate", [], "New presale rate()");
+const onChainSoftCap = await callViewWithRetry(presale, "softCap", [], "New presale softCap()");
+const onChainHardCap = await callViewWithRetry(presale, "hardCap", [], "New presale hardCap()");
+const onChainMinContribution = await callViewWithRetry(
+  presale,
+  "minContribution",
+  [],
+  "New presale minContribution()"
+);
+const onChainMaxContribution = await callViewWithRetry(
+  presale,
+  "maxContribution",
+  [],
+  "New presale maxContribution()"
+);
+const onChainStartTime = await callViewWithRetry(presale, "startTime", [], "New presale startTime()");
+const onChainEndTime = await callViewWithRetry(presale, "endTime", [], "New presale endTime()");
+const weiRaised = await callViewWithRetry(presale, "weiRaised", [], "New presale weiRaised()");
+const tokensReserved = await callViewWithRetry(
+  presale,
+  "tokensReserved",
+  [],
+  "New presale tokensReserved()"
+);
+const cancelled = await callViewWithRetry(presale, "cancelled", [], "New presale cancelled()");
+const finalized = await callViewWithRetry(presale, "finalized", [], "New presale finalized()");
 
 requireCondition(presaleOwner.toLowerCase() === wallet.address.toLowerCase(), "New presale owner is incorrect");
 requireCondition(linkedToken.toLowerCase() === tokenAddress.toLowerCase(), "New presale token linkage is incorrect");

--- a/smart-contract/scripts/inspect-invalid-presale-recovery.mjs
+++ b/smart-contract/scripts/inspect-invalid-presale-recovery.mjs
@@ -2,6 +2,11 @@ import fs from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ethers } from "ethers";
+import {
+  callViewWithRetry,
+  providerReadWithRetry,
+  readWithRetry
+} from "./lib/base-read-retry.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const deployment = JSON.parse(
@@ -21,13 +26,24 @@ const provider = new ethers.JsonRpcProvider(
   { staticNetwork: true, batchMaxCount: 1 }
 );
 
-const network = await provider.getNetwork();
+const network = await readWithRetry(
+  () => provider.getNetwork(),
+  "Base network",
+  { validate: (value) => value?.chainId !== undefined }
+);
 if (network.chainId !== 8453n) {
   throw new Error(`Expected Base chain 8453, received ${network.chainId}`);
 }
 
-const code = (await provider.getCode(invalidPresale)).toLowerCase();
-if (code === "0x") throw new Error("Invalid presale has no deployed bytecode");
+const code = (
+  await providerReadWithRetry(
+    provider,
+    "getCode",
+    [invalidPresale],
+    "Invalid presale bytecode",
+    { validate: (value) => typeof value === "string" && value !== "0x" }
+  )
+).toLowerCase();
 
 const candidateSignatures = [
   "buyTokens()",
@@ -83,21 +99,39 @@ const TOKEN_ABI = [
 
 const presale = new ethers.Contract(invalidPresale, PRESALE_ABI, provider);
 const token = new ethers.Contract(expectedToken, TOKEN_ABI, provider);
-const latestBlock = await provider.getBlock("latest");
-if (!latestBlock) throw new Error("Unable to read latest Base block");
+const latestBlock = await providerReadWithRetry(
+  provider,
+  "getBlock",
+  ["latest"],
+  "Latest Base block",
+  { validate: Boolean }
+);
 
-const [linkedToken, owner, weiRaised, cancelled, finalized, expectedTokenBalance, decimals, nativeBalance] =
-  await Promise.all([
-    presale.token(),
-    presale.owner(),
-    presale.weiRaised(),
-    presale.cancelled(),
-    presale.finalized(),
-    token.balanceOf(invalidPresale),
-    token.decimals(),
-    provider.getBalance(invalidPresale)
-  ]);
-const linkedTokenCode = await provider.getCode(linkedToken);
+const linkedToken = await callViewWithRetry(presale, "token", [], "Invalid presale token()");
+const owner = await callViewWithRetry(presale, "owner", [], "Invalid presale owner()");
+const weiRaised = await callViewWithRetry(presale, "weiRaised", [], "Invalid presale weiRaised()");
+const cancelled = await callViewWithRetry(presale, "cancelled", [], "Invalid presale cancelled()");
+const finalized = await callViewWithRetry(presale, "finalized", [], "Invalid presale finalized()");
+const expectedTokenBalance = await callViewWithRetry(
+  token,
+  "balanceOf",
+  [invalidPresale],
+  "Locked AETH balance"
+);
+const decimals = await callViewWithRetry(token, "decimals", [], "AETH decimals()");
+const nativeBalance = await providerReadWithRetry(
+  provider,
+  "getBalance",
+  [invalidPresale],
+  "Invalid presale native balance"
+);
+const linkedTokenCode = await providerReadWithRetry(
+  provider,
+  "getCode",
+  [linkedToken],
+  "Linked token bytecode",
+  { validate: (value) => typeof value === "string" }
+);
 
 function probeArgs(signature) {
   if (signature.includes("(address,address,uint256)")) return [expectedToken, owner, 0n];
@@ -139,7 +173,11 @@ async function probeSignature(signature) {
   if (signature === "buyTokens()") transaction.value = 0n;
 
   try {
-    const output = await provider.call(transaction);
+    const output = await readWithRetry(
+      () => provider.call(transaction),
+      `${signature} eth_call`,
+      { validate: (value) => typeof value === "string" }
+    );
     return {
       ethCallSucceeded: true,
       output,

--- a/smart-contract/scripts/lib/base-read-retry.mjs
+++ b/smart-contract/scripts/lib/base-read-retry.mjs
@@ -1,0 +1,55 @@
+export const DEFAULT_READ_ATTEMPTS = 5;
+export const DEFAULT_READ_DELAY_MS = 1500;
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export function describeReadError(error) {
+  return error?.shortMessage || error?.reason || error?.message || String(error);
+}
+
+export function isTransientReadError(error) {
+  const code = error?.code || "";
+  if (["BAD_DATA", "NETWORK_ERROR", "SERVER_ERROR", "TIMEOUT", "UNKNOWN_ERROR"].includes(code)) {
+    return true;
+  }
+
+  const message = describeReadError(error).toLowerCase();
+  return /could not decode result data|missing response|network|timeout|timed out|rate limit|429|502|503|504|gateway|socket|empty response/.test(message);
+}
+
+export async function readWithRetry(read, label, options = {}) {
+  const attempts = options.attempts ?? DEFAULT_READ_ATTEMPTS;
+  const delayMs = options.delayMs ?? DEFAULT_READ_DELAY_MS;
+  const validate = options.validate ?? ((value) => value !== null && value !== undefined);
+  let lastError;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const value = await read();
+      if (!validate(value)) {
+        const invalidResult = new Error(`${label} returned an invalid result`);
+        invalidResult.code = "INVALID_READ_RESULT";
+        throw invalidResult;
+      }
+      return value;
+    } catch (error) {
+      lastError = error;
+      const retryable = error?.code === "INVALID_READ_RESULT" || isTransientReadError(error);
+      if (!retryable || attempt === attempts) break;
+      console.warn(`${label} read attempt ${attempt}/${attempts} failed: ${describeReadError(error)}`);
+      await sleep(delayMs);
+    }
+  }
+
+  throw new Error(`${label} could not be read after ${attempts} attempts: ${describeReadError(lastError)}`);
+}
+
+export function callViewWithRetry(contract, method, args = [], label = `${method}()`, options = {}) {
+  return readWithRetry(() => contract[method](...args), label, options);
+}
+
+export function providerReadWithRetry(provider, method, args = [], label = method, options = {}) {
+  return readWithRetry(() => provider[method](...args), label, options);
+}

--- a/smart-contract/scripts/verify-base-presale-state.mjs
+++ b/smart-contract/scripts/verify-base-presale-state.mjs
@@ -1,5 +1,10 @@
 import fs from "node:fs/promises";
 import { ethers } from "ethers";
+import {
+  callViewWithRetry,
+  providerReadWithRetry,
+  readWithRetry
+} from "./lib/base-read-retry.mjs";
 
 const deploymentUrl = new URL("../deployments/presale-base.json", import.meta.url);
 const deployment = JSON.parse(await fs.readFile(deploymentUrl, "utf8"));
@@ -33,7 +38,11 @@ const provider = new ethers.JsonRpcProvider(process.env.BASE_RPC_URL || "https:/
   staticNetwork: true,
   batchMaxCount: 1
 });
-const network = await provider.getNetwork();
+const network = await readWithRetry(
+  () => provider.getNetwork(),
+  "Base network",
+  { validate: (value) => value?.chainId !== undefined }
+);
 requireCondition(network.chainId === 8453n, `Expected Base chain 8453, received ${network.chainId}`);
 
 const TOKEN_ABI = [
@@ -60,58 +69,62 @@ const PRESALE_ABI = [
   "function finalized() view returns (bool)"
 ];
 
-const [tokenCode, presaleCode] = await Promise.all([
-  provider.getCode(expectedTokenAddress),
-  provider.getCode(activePresaleAddress)
-]);
+const tokenCode = await providerReadWithRetry(
+  provider,
+  "getCode",
+  [expectedTokenAddress],
+  "Approved AETH bytecode",
+  { validate: (value) => typeof value === "string" && value !== "0x" }
+);
+const presaleCode = await providerReadWithRetry(
+  provider,
+  "getCode",
+  [activePresaleAddress],
+  "Replacement presale bytecode",
+  { validate: (value) => typeof value === "string" && value !== "0x" }
+);
 requireCondition(tokenCode !== "0x", "Approved AETH token has no Base bytecode");
 requireCondition(presaleCode !== "0x", "Replacement presale has no Base bytecode");
 
 const token = new ethers.Contract(expectedTokenAddress, TOKEN_ABI, provider);
 const presale = new ethers.Contract(activePresaleAddress, PRESALE_ABI, provider);
-const [
-  tokenOwner,
-  tokenDecimals,
-  tradingEnabled,
-  inventory,
-  taxExcluded,
-  presaleOwner,
-  linkedToken,
-  linkedTreasury,
-  rate,
-  softCap,
-  hardCap,
-  minimum,
-  maximum,
-  startTime,
-  endTime,
-  weiRaised,
-  tokensReserved,
-  cancelled,
-  finalized,
-  latestBlock
-] = await Promise.all([
-  token.owner(),
-  token.decimals(),
-  token.tradingEnabled(),
-  token.balanceOf(activePresaleAddress),
-  token.isExcludedFromTax(activePresaleAddress),
-  presale.owner(),
-  presale.token(),
-  presale.treasury(),
-  presale.rate(),
-  presale.softCap(),
-  presale.hardCap(),
-  presale.minContribution(),
-  presale.maxContribution(),
-  presale.startTime(),
-  presale.endTime(),
-  presale.weiRaised(),
-  presale.tokensReserved(),
-  presale.cancelled(),
-  presale.finalized(),
-  provider.getBlock("latest")
-]);
+
+const tokenOwner = await callViewWithRetry(token, "owner", [], "AETH owner()");
+const tokenDecimals = await callViewWithRetry(token, "decimals", [], "AETH decimals()");
+const tradingEnabled = await callViewWithRetry(token, "tradingEnabled", [], "AETH tradingEnabled()");
+const inventory = await callViewWithRetry(
+  token,
+  "balanceOf",
+  [activePresaleAddress],
+  "Replacement AETH inventory"
+);
+const taxExcluded = await callViewWithRetry(
+  token,
+  "isExcludedFromTax",
+  [activePresaleAddress],
+  "Replacement tax exclusion"
+);
+const presaleOwner = await callViewWithRetry(presale, "owner", [], "Replacement owner()");
+const linkedToken = await callViewWithRetry(presale, "token", [], "Replacement token()");
+const linkedTreasury = await callViewWithRetry(presale, "treasury", [], "Replacement treasury()");
+const rate = await callViewWithRetry(presale, "rate", [], "Replacement rate()");
+const softCap = await callViewWithRetry(presale, "softCap", [], "Replacement softCap()");
+const hardCap = await callViewWithRetry(presale, "hardCap", [], "Replacement hardCap()");
+const minimum = await callViewWithRetry(presale, "minContribution", [], "Replacement minContribution()");
+const maximum = await callViewWithRetry(presale, "maxContribution", [], "Replacement maxContribution()");
+const startTime = await callViewWithRetry(presale, "startTime", [], "Replacement startTime()");
+const endTime = await callViewWithRetry(presale, "endTime", [], "Replacement endTime()");
+const weiRaised = await callViewWithRetry(presale, "weiRaised", [], "Replacement weiRaised()");
+const tokensReserved = await callViewWithRetry(presale, "tokensReserved", [], "Replacement tokensReserved()");
+const cancelled = await callViewWithRetry(presale, "cancelled", [], "Replacement cancelled()");
+const finalized = await callViewWithRetry(presale, "finalized", [], "Replacement finalized()");
+const latestBlock = await providerReadWithRetry(
+  provider,
+  "getBlock",
+  ["latest"],
+  "Latest Base block",
+  { validate: Boolean }
+);
 
 requireCondition(tokenDecimals === 18n, "AETH token decimals are not 18");
 requireCondition(tokenOwner.toLowerCase() === expectedOwner.toLowerCase(), "AETH owner does not match the deployment record");

--- a/smart-contract/scripts/verify-base-readonly.mjs
+++ b/smart-contract/scripts/verify-base-readonly.mjs
@@ -2,6 +2,11 @@ import fs from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import { ethers } from "ethers";
+import {
+  callViewWithRetry,
+  providerReadWithRetry,
+  readWithRetry
+} from "./lib/base-read-retry.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const deploymentPath = resolve(__dirname, "../deployments/presale-base.json");
@@ -70,7 +75,7 @@ async function safeCall(contract, method, args = []) {
   try {
     return {
       supported: true,
-      value: await contract[method](...args),
+      value: await callViewWithRetry(contract, method, args, `${method}()`),
       error: null
     };
   } catch (error) {
@@ -83,18 +88,21 @@ async function safeCall(contract, method, args = []) {
 }
 
 async function inspectExpectedToken() {
-  const code = await provider.getCode(expectedTokenAddress);
-  requireCondition(code !== "0x", "No bytecode exists at the configured AETH token address");
+  const code = await providerReadWithRetry(
+    provider,
+    "getCode",
+    [expectedTokenAddress],
+    "AETH bytecode",
+    { validate: (value) => typeof value === "string" && value !== "0x" }
+  );
 
   const token = new ethers.Contract(expectedTokenAddress, TOKEN_ABI, provider);
-  const [name, symbol, decimals, totalSupply, owner, tradingEnabled] = await Promise.all([
-    token.name(),
-    token.symbol(),
-    token.decimals(),
-    token.totalSupply(),
-    token.owner(),
-    token.tradingEnabled()
-  ]);
+  const name = await callViewWithRetry(token, "name", [], "AETH name()");
+  const symbol = await callViewWithRetry(token, "symbol", [], "AETH symbol()");
+  const decimals = await callViewWithRetry(token, "decimals", [], "AETH decimals()");
+  const totalSupply = await callViewWithRetry(token, "totalSupply", [], "AETH totalSupply()");
+  const owner = await callViewWithRetry(token, "owner", [], "AETH owner()");
+  const tradingEnabled = await callViewWithRetry(token, "tradingEnabled", [], "AETH tradingEnabled()");
 
   return { token, code, name, symbol, decimals, totalSupply, owner, tradingEnabled };
 }
@@ -102,11 +110,16 @@ async function inspectExpectedToken() {
 async function inspectPresale(address, expectedToken) {
   requireCondition(ethers.isAddress(address), "Presale address is invalid");
 
-  const code = await provider.getCode(address);
-  requireCondition(code !== "0x", `No bytecode exists at presale ${address}`);
+  const code = await providerReadWithRetry(
+    provider,
+    "getCode",
+    [address],
+    `Presale ${address} bytecode`,
+    { validate: (value) => typeof value === "string" && value !== "0x" }
+  );
   const presale = new ethers.Contract(address, PRESALE_ABI, provider);
 
-  const fields = Object.fromEntries(await Promise.all([
+  const methods = [
     "token",
     "treasury",
     "owner",
@@ -122,26 +135,47 @@ async function inspectPresale(address, expectedToken) {
     "finalized",
     "cancelled",
     "refundsAvailable"
-  ].map(async (method) => [method, await safeCall(presale, method)])));
+  ];
+  const fields = {};
+  for (const method of methods) {
+    fields[method] = await safeCall(presale, method);
+  }
 
   requireCondition(fields.token.supported, "Presale does not expose token()");
   const linkedToken = fields.token.value;
-  const [nativeBalance, expectedTokenBalance, expectedTokenTaxExcluded] = await Promise.all([
-    provider.getBalance(address),
-    expectedToken.token.balanceOf(address),
-    expectedToken.token.isExcludedFromTax(address)
-  ]);
+  const nativeBalance = await providerReadWithRetry(
+    provider,
+    "getBalance",
+    [address],
+    `Presale ${address} native balance`
+  );
+  const expectedTokenBalance = await callViewWithRetry(
+    expectedToken.token,
+    "balanceOf",
+    [address],
+    `AETH balanceOf(${address})`
+  );
+  const expectedTokenTaxExcluded = await callViewWithRetry(
+    expectedToken.token,
+    "isExcludedFromTax",
+    [address],
+    `AETH isExcludedFromTax(${address})`
+  );
 
-  const linkedTokenCode = await provider.getCode(linkedToken);
+  const linkedTokenCode = await providerReadWithRetry(
+    provider,
+    "getCode",
+    [linkedToken],
+    `Linked token ${linkedToken} bytecode`,
+    { validate: (value) => typeof value === "string" }
+  );
   let linkedTokenMetadata = null;
   if (linkedTokenCode !== "0x") {
     const linkedTokenContract = new ethers.Contract(linkedToken, TOKEN_ABI, provider);
-    const [name, symbol, decimals, balance] = await Promise.all([
-      safeCall(linkedTokenContract, "name"),
-      safeCall(linkedTokenContract, "symbol"),
-      safeCall(linkedTokenContract, "decimals"),
-      safeCall(linkedTokenContract, "balanceOf", [address])
-    ]);
+    const name = await safeCall(linkedTokenContract, "name");
+    const symbol = await safeCall(linkedTokenContract, "symbol");
+    const decimals = await safeCall(linkedTokenContract, "decimals");
+    const balance = await safeCall(linkedTokenContract, "balanceOf", [address]);
 
     linkedTokenMetadata = {
       name: name.value,
@@ -159,7 +193,13 @@ async function inspectPresale(address, expectedToken) {
     };
   }
 
-  const latestBlock = await provider.getBlock("latest");
+  const latestBlock = await providerReadWithRetry(
+    provider,
+    "getBlock",
+    ["latest"],
+    "Latest Base block",
+    { validate: Boolean }
+  );
   const now = BigInt(latestBlock.timestamp);
   const startTime = fields.startTime.value;
   const endTime = fields.endTime.value;
@@ -205,10 +245,19 @@ async function inspectPresale(address, expectedToken) {
   };
 }
 
-const network = await provider.getNetwork();
+const network = await readWithRetry(
+  () => provider.getNetwork(),
+  "Base network",
+  { validate: (value) => value?.chainId !== undefined }
+);
 requireCondition(network.chainId === 8453n, `Expected Base chain 8453, received ${network.chainId}`);
-const latestBlock = await provider.getBlock("latest");
-requireCondition(latestBlock, "Unable to read latest Base block");
+const latestBlock = await providerReadWithRetry(
+  provider,
+  "getBlock",
+  ["latest"],
+  "Latest Base block",
+  { validate: Boolean }
+);
 
 const expectedToken = await inspectExpectedToken();
 const tokenReport = {

--- a/smart-contract/test/BaseForkReadOnly.fork.js
+++ b/smart-contract/test/BaseForkReadOnly.fork.js
@@ -4,6 +4,11 @@ import path from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 import { network } from "hardhat";
+import {
+  callViewWithRetry,
+  providerReadWithRetry,
+  readWithRetry
+} from "../scripts/lib/base-read-retry.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const deployment = JSON.parse(
@@ -36,26 +41,66 @@ const TOKEN_ABI = [
 
 describe("Base mainnet fork", { concurrency: false }, function () {
   it("proves the configured deployment state without spending real ETH", async function () {
-    const { ethers } = await network.connect("baseFork");
+    const connection = await readWithRetry(
+      () => network.connect("baseFork"),
+      "Base fork connection",
+      { validate: (value) => Boolean(value?.ethers) }
+    );
+    const { ethers } = connection;
     const [buyer] = await ethers.getSigners();
 
-    const tokenCode = await ethers.provider.getCode(TOKEN_ADDRESS);
+    const tokenCode = await providerReadWithRetry(
+      ethers.provider,
+      "getCode",
+      [TOKEN_ADDRESS],
+      "Forked AETH bytecode",
+      { validate: (value) => typeof value === "string" && value !== "0x" }
+    );
     assert.notEqual(tokenCode, "0x", "AETH token bytecode is missing on the Base fork");
     const token = new ethers.Contract(TOKEN_ADDRESS, TOKEN_ABI, ethers.provider);
 
     if (!ACTIVE_PRESALE_ADDRESS) {
       assert.ok(INVALID_PRESALE_ADDRESS, "No active or invalid presale address is recorded");
-      const invalidCode = await ethers.provider.getCode(INVALID_PRESALE_ADDRESS);
+      const invalidCode = await providerReadWithRetry(
+        ethers.provider,
+        "getCode",
+        [INVALID_PRESALE_ADDRESS],
+        "Forked invalid presale bytecode",
+        { validate: (value) => typeof value === "string" && value !== "0x" }
+      );
       assert.notEqual(invalidCode, "0x", "Recorded invalid presale bytecode is missing");
 
       const invalidPresale = new ethers.Contract(INVALID_PRESALE_ADDRESS, PRESALE_ABI, ethers.provider);
-      const [linkedToken, expectedTokenBalance, weiRaised, cancelled, finalized] = await Promise.all([
-        invalidPresale.token(),
-        token.balanceOf(INVALID_PRESALE_ADDRESS),
-        invalidPresale.weiRaised(),
-        invalidPresale.cancelled(),
-        invalidPresale.finalized()
-      ]);
+      const linkedToken = await callViewWithRetry(
+        invalidPresale,
+        "token",
+        [],
+        "Forked invalid presale token()"
+      );
+      const expectedTokenBalance = await callViewWithRetry(
+        token,
+        "balanceOf",
+        [INVALID_PRESALE_ADDRESS],
+        "Forked locked AETH balance"
+      );
+      const weiRaised = await callViewWithRetry(
+        invalidPresale,
+        "weiRaised",
+        [],
+        "Forked invalid presale weiRaised()"
+      );
+      const cancelled = await callViewWithRetry(
+        invalidPresale,
+        "cancelled",
+        [],
+        "Forked invalid presale cancelled()"
+      );
+      const finalized = await callViewWithRetry(
+        invalidPresale,
+        "finalized",
+        [],
+        "Forked invalid presale finalized()"
+      );
 
       assert.notEqual(
         linkedToken.toLowerCase(),
@@ -75,39 +120,75 @@ describe("Base mainnet fork", { concurrency: false }, function () {
       return;
     }
 
-    const presaleCode = await ethers.provider.getCode(ACTIVE_PRESALE_ADDRESS);
+    const presaleCode = await providerReadWithRetry(
+      ethers.provider,
+      "getCode",
+      [ACTIVE_PRESALE_ADDRESS],
+      "Forked replacement presale bytecode",
+      { validate: (value) => typeof value === "string" && value !== "0x" }
+    );
     assert.notEqual(presaleCode, "0x", "Presale bytecode is missing on the Base fork");
 
     const presale = new ethers.Contract(ACTIVE_PRESALE_ADDRESS, PRESALE_ABI, buyer);
-    const [
-      linkedToken,
-      rate,
-      raisedBefore,
-      reserved,
-      hardCap,
-      minContribution,
-      maxContribution,
-      startTime,
-      endTime,
-      finalized,
-      cancelled,
-      inventory,
-      latestBlock
-    ] = await Promise.all([
-      presale.token(),
-      presale.rate(),
-      presale.weiRaised(),
-      presale.tokensReserved(),
-      presale.hardCap(),
-      presale.minContribution(),
-      presale.maxContribution(),
-      presale.startTime(),
-      presale.endTime(),
-      presale.finalized(),
-      presale.cancelled(),
-      token.balanceOf(ACTIVE_PRESALE_ADDRESS),
-      ethers.provider.getBlock("latest")
-    ]);
+    const linkedToken = await callViewWithRetry(presale, "token", [], "Forked replacement token()");
+    const rate = await callViewWithRetry(presale, "rate", [], "Forked replacement rate()");
+    const raisedBefore = await callViewWithRetry(
+      presale,
+      "weiRaised",
+      [],
+      "Forked replacement weiRaised()"
+    );
+    const reserved = await callViewWithRetry(
+      presale,
+      "tokensReserved",
+      [],
+      "Forked replacement tokensReserved()"
+    );
+    const hardCap = await callViewWithRetry(presale, "hardCap", [], "Forked replacement hardCap()");
+    const minContribution = await callViewWithRetry(
+      presale,
+      "minContribution",
+      [],
+      "Forked replacement minContribution()"
+    );
+    const maxContribution = await callViewWithRetry(
+      presale,
+      "maxContribution",
+      [],
+      "Forked replacement maxContribution()"
+    );
+    const startTime = await callViewWithRetry(
+      presale,
+      "startTime",
+      [],
+      "Forked replacement startTime()"
+    );
+    const endTime = await callViewWithRetry(presale, "endTime", [], "Forked replacement endTime()");
+    const finalized = await callViewWithRetry(
+      presale,
+      "finalized",
+      [],
+      "Forked replacement finalized()"
+    );
+    const cancelled = await callViewWithRetry(
+      presale,
+      "cancelled",
+      [],
+      "Forked replacement cancelled()"
+    );
+    const inventory = await callViewWithRetry(
+      token,
+      "balanceOf",
+      [ACTIVE_PRESALE_ADDRESS],
+      "Forked replacement AETH inventory"
+    );
+    const latestBlock = await providerReadWithRetry(
+      ethers.provider,
+      "getBlock",
+      ["latest"],
+      "Forked latest block",
+      { validate: Boolean }
+    );
 
     assert.equal(linkedToken.toLowerCase(), TOKEN_ADDRESS.toLowerCase());
     assert.ok(inventory >= reserved, "Presale inventory is below reserved liabilities");
@@ -142,12 +223,33 @@ describe("Base mainnet fork", { concurrency: false }, function () {
     }
 
     const buyerAddress = await buyer.getAddress();
-    const contributionBefore = await presale.contributions(buyerAddress);
-    await presale.buyTokens.staticCall({ value: minContribution });
+    const contributionBefore = await callViewWithRetry(
+      presale,
+      "contributions",
+      [buyerAddress],
+      "Forked buyer contribution"
+    );
+    await readWithRetry(
+      () => presale.buyTokens.staticCall({ value: minContribution }),
+      "Forked purchase static call",
+      { validate: (value) => value !== undefined }
+    );
     const tx = await presale.buyTokens({ value: minContribution });
     await tx.wait();
 
-    assert.equal(await presale.weiRaised(), raisedBefore + minContribution);
-    assert.equal(await presale.contributions(buyerAddress), contributionBefore + minContribution);
+    const raisedAfter = await callViewWithRetry(
+      presale,
+      "weiRaised",
+      [],
+      "Forked post-purchase weiRaised()"
+    );
+    const contributionAfter = await callViewWithRetry(
+      presale,
+      "contributions",
+      [buyerAddress],
+      "Forked post-purchase contribution"
+    );
+    assert.equal(raisedAfter, raisedBefore + minContribution);
+    assert.equal(contributionAfter, contributionBefore + minContribution);
   });
 });

--- a/smart-contract/test/ProductionPresaleConfig.test.js
+++ b/smart-contract/test/ProductionPresaleConfig.test.js
@@ -81,6 +81,25 @@ test("all production deployment entry points use the invariant guard", () => {
   assert.match(productionGuardSource, /Protected signer is not the approved Base owner\/treasury wallet/);
 });
 
+test("production guard retries transient Base view failures before deployment", () => {
+  assert.match(productionGuardSource, /const VIEW_RETRY_ATTEMPTS = 5/);
+  assert.match(productionGuardSource, /async function readViewWithRetry/);
+  assert.match(productionGuardSource, /Invalid presale token\(\)/);
+  assert.doesNotMatch(
+    productionGuardSource,
+    /Promise\.all\(\[\s*invalidPresale\.owner\(\),\s*invalidPresale\.token\(\)/
+  );
+
+  const tokenReadIndex = productionGuardSource.indexOf(
+    'readViewWithRetry(invalidPresale, "token", "Invalid presale token()")'
+  );
+  const deploymentImportIndex = productionGuardSource.indexOf(
+    'await import("./deploy-base-presale-safe.mjs")'
+  );
+  assert.ok(tokenReadIndex >= 0);
+  assert.ok(deploymentImportIndex > tokenReadIndex);
+});
+
 test("post-deployment verification accepts a fully funded disabled replacement", () => {
   assert.equal(packageJson.scripts["verify:base:readonly"], "node scripts/verify-base-presale-state.mjs");
   assert.match(stateVerifierSource, /safeDisabledState/);

--- a/smart-contract/test/ProductionPresaleSimulation.test.js
+++ b/smart-contract/test/ProductionPresaleSimulation.test.js
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { describe, it } from "node:test";
+import { network } from "hardhat";
+
+const production = JSON.parse(
+  fs.readFileSync(new URL("../config/presale-base-production.json", import.meta.url), "utf8")
+);
+
+describe("Exact production presale simulation", { concurrency: false }, function () {
+  it("deploys, funds, purchases, escrows, cancels, and refunds with production values", async function () {
+    const { ethers } = await network.connect();
+    const [owner, treasury, buyer] = await ethers.getSigners();
+
+    const rate = BigInt(production.rateAethPerEth);
+    const softCap = ethers.parseEther(production.softCapEth);
+    const hardCap = ethers.parseEther(production.hardCapEth);
+    const minimum = ethers.parseEther(production.minContributionEth);
+    const maximum = ethers.parseEther(production.maxContributionEth);
+    const fundingAmount = ethers.parseUnits(production.fundingAeth, 18);
+    const startDelay = Number(production.startDelaySeconds);
+    const duration = Number(production.durationSeconds);
+
+    assert.equal(hardCap * rate, fundingAmount, "Production funding arithmetic must be exact");
+
+    const Token = await ethers.getContractFactory("contracts/Aetheron.sol:Aetheron");
+    const token = await Token.deploy(owner.address, owner.address, owner.address);
+    await token.waitForDeployment();
+
+    const latestBlock = await ethers.provider.getBlock("latest");
+    assert.ok(latestBlock);
+    const startTime = latestBlock.timestamp + startDelay;
+    const endTime = startTime + duration;
+
+    const Presale = await ethers.getContractFactory("AetheronPresaleV2");
+    const presale = await Presale.deploy(
+      await token.getAddress(),
+      rate,
+      softCap,
+      hardCap,
+      minimum,
+      maximum,
+      startTime,
+      endTime,
+      treasury.address
+    );
+    await presale.waitForDeployment();
+
+    const presaleAddress = await presale.getAddress();
+    await (await token.setExcludedFromTax(presaleAddress, true)).wait();
+    await (await token.transfer(presaleAddress, fundingAmount)).wait();
+
+    assert.equal(await token.balanceOf(presaleAddress), fundingAmount);
+    assert.equal(await token.isExcludedFromTax(presaleAddress), true);
+    assert.equal(await presale.owner(), owner.address);
+    assert.equal(await presale.token(), await token.getAddress());
+    assert.equal(await presale.treasury(), treasury.address);
+    assert.equal(await presale.rate(), rate);
+    assert.equal(await presale.softCap(), softCap);
+    assert.equal(await presale.hardCap(), hardCap);
+    assert.equal(await presale.minContribution(), minimum);
+    assert.equal(await presale.maxContribution(), maximum);
+    assert.equal(await presale.startTime(), BigInt(startTime));
+    assert.equal(await presale.endTime(), BigInt(endTime));
+
+    await ethers.provider.send("evm_setNextBlockTimestamp", [startTime + 1]);
+    await ethers.provider.send("evm_mine");
+
+    const expectedTokens = minimum * rate;
+    await (await presale.connect(buyer).buyTokens({ value: minimum })).wait();
+
+    assert.equal(await presale.weiRaised(), minimum);
+    assert.equal(await presale.contributions(buyer.address), minimum);
+    assert.equal(await presale.tokensOwed(buyer.address), expectedTokens);
+    assert.equal(await presale.tokensReserved(), expectedTokens);
+    assert.equal(await ethers.provider.getBalance(presaleAddress), minimum);
+    assert.equal(await token.balanceOf(presaleAddress), fundingAmount);
+
+    await (await presale.cancel()).wait();
+    assert.equal(await presale.refundsAvailable(), true);
+
+    const contractBalanceBeforeRefund = await ethers.provider.getBalance(presaleAddress);
+    await (await presale.connect(buyer).claimRefund()).wait();
+
+    assert.equal(await presale.contributions(buyer.address), 0n);
+    assert.equal(await presale.tokensOwed(buyer.address), 0n);
+    assert.equal(await presale.tokensReserved(), 0n);
+    assert.equal(await ethers.provider.getBalance(presaleAddress), contractBalanceBeforeRefund - minimum);
+    assert.equal(await token.balanceOf(presaleAddress), fundingAmount);
+  });
+});


### PR DESCRIPTION
## Fixes

- retries transient Base RPC read failures such as empty `0x` responses and `BAD_DATA`
- applies bounded sequential reads before deployment, after deployment, in recovery inspection, state verification, and fork diagnostics
- separates the normal Base read RPC from a fork-capable RPC
- stops treating the rate-limited public Base endpoint as a reliable Hardhat archive-fork service
- adds an exact deterministic production simulation using the approved rate, caps, allocation, limits, schedule, tax exclusion, escrow purchase, cancellation, and refund flow
- makes compile, unit tests, exact production simulation, live read-only Base verification, owner-bound dry run, and recovery inspection mandatory
- keeps archive-fork testing as an optional diagnostic so it cannot create a false failure after a real deployment transaction
- preserves disabled frontend/public purchases throughout

## Safety

No workflow is dispatched and no transaction is sent by this PR. Existing signer, token-linkage, cancellation, economics, funding, journal, BaseScan, disabled-frontend, and owner-authorization gates remain enforced.