### PR TITLE
Retry transient zero Base gas balance

### DIFF
--- a/smart-contract/scripts/lib/base-read-retry.mjs
+++ b/smart-contract/scripts/lib/base-read-retry.mjs
@@ -51,5 +51,12 @@ export function callViewWithRetry(contract, method, args = [], label = `${method
 }
 
 export function providerReadWithRetry(provider, method, args = [], label = method, options = {}) {
-  return readWithRetry(() => provider[method](...args), label, options);
+  const deployerGasBalanceRead =
+    method === "getBalance" && label === "Deployment wallet Base ETH balance";
+  const effectiveOptions =
+    deployerGasBalanceRead && options.validate === undefined
+      ? { ...options, validate: (value) => typeof value === "bigint" && value > 0n }
+      : options;
+
+  return readWithRetry(() => provider[method](...args), label, effectiveOptions);
 }


### PR DESCRIPTION
## Fix

- treats a zero `getBalance` result as invalid only for the deployment wallet Base ETH check
- retries that read through the existing bounded retry path
- preserves legitimate zero-balance reads elsewhere
- leaves every signer, cancellation, economics, funding, verification, journal, and disabled-frontend safeguard unchanged

## Incident

The live workflow passed the production guard and invalid-presale cancellation check, but nearby RPC reads returned invalid data and the deployer balance was transiently reported as zero. No replacement address or transaction hash was recorded.

## Safety

This PR does not dispatch a workflow and does not send a Base transaction.