### PR TITLE
Correct Base presale contribution limits

### DIFF
--- a/presale-config.js
+++ b/presale-config.js
@@ -8,6 +8,6 @@ window.AETHERON_PRESALE_CONFIG = {
   network: "base",
   chainId: 8453,
   nativeSymbol: "ETH",
-  minContribution: 0.001,
-  maxContribution: 1
+  minContribution: 0.0003,
+  maxContribution: 33.333333
 };

--- a/presale.html
+++ b/presale.html
@@ -11,167 +11,31 @@
     crossorigin="anonymous" referrerpolicy="no-referrer">
   <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js" defer></script>
   <style>
-    .hidden {
-      display: none;
-    }
-
-    .text-center {
-      text-align: center;
-    }
-
-    .text-muted {
-      color: #64748b;
-    }
-
-    .text-error {
-      color: #ef4444;
-    }
-
-    .margin-reset {
-      margin: 0 0 0.75rem 0;
-    }
-
-    .margin-top {
-      margin-top: 1rem;
-    }
-
-    body {
-      font-family: Inter, sans-serif;
-      background: linear-gradient(135deg, var(--primary) 0, var(--secondary) 100%);
-      min-height: 100vh;
-      color: var(--dark);
-      margin: 0;
-      padding: 20px
-    }
-
-    .container {
-      max-width: 800px;
-      margin: 2rem auto;
-      background: rgba(255, 255, 255, .95);
-      border-radius: 24px;
-      padding: 3rem;
-      box-shadow: 0 10px 25px rgba(0, 0, 0, .2)
-    }
-
-    .header {
-      text-align: center;
-      margin-bottom: 2rem
-    }
-
-    .header h1 {
-      background: linear-gradient(135deg, var(--primary), var(--secondary));
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      font-size: 2.5rem;
-      margin-bottom: 1rem
-    }
-
-    .card {
-      background: #fff;
-      border-radius: 16px;
-      padding: 2rem;
-      margin-bottom: 1.5rem;
-      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, .1);
-      border: 1px solid #e5e7eb
-    }
-
-    .stats-grid {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-      gap: 1.5rem;
-      margin-bottom: 2rem
-    }
-
-    .stat-box {
-      background: #f8fafc;
-      padding: 1.5rem;
-      border-radius: 12px;
-      text-align: center
-    }
-
-    .stat-value {
-      font-size: 1.5rem;
-      font-weight: 700;
-      color: var(--primary)
-    }
-
-    .input-group {
-      margin-bottom: 1rem
-    }
-
-    .input-group label {
-      display: block;
-      margin-bottom: .5rem;
-      font-weight: 600
-    }
-
-    .input-group input {
-      width: 100%;
-      padding: 1rem;
-      border: 2px solid #e2e8f0;
-      border-radius: 12px;
-      font-size: 1.1rem;
-      transition: border-color .3s
-    }
-
-    .input-group input:focus {
-      outline: 0;
-      border-color: var(--primary)
-    }
-
-    button {
-      width: 100%;
-      padding: 1rem;
-      background: linear-gradient(135deg, var(--primary), var(--secondary));
-      color: #fff;
-      border: none;
-      border-radius: 12px;
-      font-size: 1.1rem;
-      font-weight: 600;
-      cursor: pointer;
-      transition: transform .2s, opacity .2s
-    }
-
-    button:hover {
-      transform: translateY(-2px);
-      opacity: .95
-    }
-
-    button:disabled {
-      background: #cbd5e1;
-      cursor: not-allowed;
-      transform: none
-    }
-
-    .progress-bar {
-      width: 100%;
-      height: 12px;
-      background: #e2e8f0;
-      border-radius: 6px;
-      margin: 1rem 0;
-      overflow: hidden
-    }
-
-    .progress-fill {
-      height: 100%;
-      background: var(--success);
-      width: 0%;
-      transition: width .5s ease
-    }
-
-    .nav-back {
-      display: inline-block;
-      margin-bottom: 1rem;
-      color: #fff;
-      text-decoration: none;
-      font-weight: 500
-    }
-
-    #wallet-status {
-      text-align: center;
-      margin-bottom: 1rem;
-      font-weight: 500
-    }
+    .hidden { display: none; }
+    .text-center { text-align: center; }
+    .text-muted { color: #64748b; }
+    .text-error { color: #ef4444; }
+    .margin-reset { margin: 0 0 0.75rem 0; }
+    .margin-top { margin-top: 1rem; }
+    body { font-family: Inter, sans-serif; background: linear-gradient(135deg, var(--primary) 0, var(--secondary) 100%); min-height: 100vh; color: var(--dark); margin: 0; padding: 20px }
+    .container { max-width: 800px; margin: 2rem auto; background: rgba(255, 255, 255, .95); border-radius: 24px; padding: 3rem; box-shadow: 0 10px 25px rgba(0, 0, 0, .2) }
+    .header { text-align: center; margin-bottom: 2rem }
+    .header h1 { background: linear-gradient(135deg, var(--primary), var(--secondary)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; font-size: 2.5rem; margin-bottom: 1rem }
+    .card { background: #fff; border-radius: 16px; padding: 2rem; margin-bottom: 1.5rem; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, .1); border: 1px solid #e5e7eb }
+    .stats-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1.5rem; margin-bottom: 2rem }
+    .stat-box { background: #f8fafc; padding: 1.5rem; border-radius: 12px; text-align: center }
+    .stat-value { font-size: 1.5rem; font-weight: 700; color: var(--primary) }
+    .input-group { margin-bottom: 1rem }
+    .input-group label { display: block; margin-bottom: .5rem; font-weight: 600 }
+    .input-group input { width: 100%; padding: 1rem; border: 2px solid #e2e8f0; border-radius: 12px; font-size: 1.1rem; transition: border-color .3s }
+    .input-group input:focus { outline: 0; border-color: var(--primary) }
+    button { width: 100%; padding: 1rem; background: linear-gradient(135deg, var(--primary), var(--secondary)); color: #fff; border: none; border-radius: 12px; font-size: 1.1rem; font-weight: 600; cursor: pointer; transition: transform .2s, opacity .2s }
+    button:hover { transform: translateY(-2px); opacity: .95 }
+    button:disabled { background: #cbd5e1; cursor: not-allowed; transform: none }
+    .progress-bar { width: 100%; height: 12px; background: #e2e8f0; border-radius: 6px; margin: 1rem 0; overflow: hidden }
+    .progress-fill { height: 100%; background: var(--success); width: 0%; transition: width .5s ease }
+    .nav-back { display: inline-block; margin-bottom: 1rem; color: #fff; text-decoration: none; font-weight: 500 }
+    #wallet-status { text-align: center; margin-bottom: 1rem; font-weight: 500 }
   </style>
   <link rel="stylesheet" href="shared-mobile-polish.css?v=1.3.0">
 </head>
@@ -182,43 +46,25 @@
       <h1>Aetheron Community Presale</h1>
       <p>Support the liquidity launch and get AETH tokens early!</p>
     </div>
-    <div id="wallet-status"><button id="connectBtn" onclick="connectWallet()">Connect Wallet</button> <span
-        id="walletAddress" class="hidden"></span></div>
+    <div id="wallet-status"><button id="connectBtn" onclick="connectWallet()">Connect Wallet</button> <span id="walletAddress" class="hidden"></span></div>
     <div class="card">
       <h3>Presale Status</h3>
       <div class="stats-grid">
-        <div class="stat-box">
-          <div class="label">Rate</div>
-          <div class="stat-value" id="rateDisplay">1 ETH = 1000 AETH</div>
-        </div>
-        <div class="stat-box">
-          <div class="label">Total Raised</div>
-          <div class="stat-value" id="raisedDisplay">0 ETH</div>
-        </div>
-        <div class="stat-box">
-          <div class="label">Max Tokens</div>
-          <div class="stat-value" id="maxTokensDisplay">40,000,000 AETH</div>
-        </div>
-        <div class="stat-box">
-          <div class="label">Max Raise</div>
-          <div class="stat-value" id="maxRaiseDisplay">$25,000</div>
-        </div>
+        <div class="stat-box"><div class="label">Rate</div><div class="stat-value" id="rateDisplay">1 ETH = 1000 AETH</div></div>
+        <div class="stat-box"><div class="label">Total Raised</div><div class="stat-value" id="raisedDisplay">0 ETH</div></div>
+        <div class="stat-box"><div class="label">Max Tokens</div><div class="stat-value" id="maxTokensDisplay">40,000,000 AETH</div></div>
+        <div class="stat-box"><div class="label">Max Raise</div><div class="stat-value" id="maxRaiseDisplay">$25,000</div></div>
       </div>
-      <div class="progress-bar">
-        <div class="progress-fill" id="progressBar"></div>
-      </div>
+      <div class="progress-bar"><div class="progress-fill" id="progressBar"></div></div>
       <p class="text-center text-muted" id="capStatus">Checking presale contract status...</p>
       <p class="text-center" id="refundSection" style="display:none;margin-top:10px;"><button onclick="claimRefund()" style="background:#ef4444;color:#fff;padding:8px 16px;border-radius:8px;border:none;cursor:pointer;">Claim Refund</button></p>
       <p class="text-center" id="withdrawSection" style="display:none;margin-top:10px;"><button onclick="withdrawToTreasury()" style="background:linear-gradient(135deg,#6366f1,#8b5cf6);color:#fff;padding:8px 16px;border-radius:8px;border:none;cursor:pointer;">Withdraw Funds to Treasury</button></p>
     </div>
     <div class="card">
       <h3>Buy AETH</h3>
-<div class="input-group"><label>Amount in ETH</label> <input type="number" id="maticAmount"
-          placeholder="Min 0.001 ETH" oninput="calculateTokens()"></div>
-      <div class="input-group"><label>You Will Receive (Approx)</label> <input type="text" id="tokenAmount"
-          disabled="disabled" placeholder="0 AETH"></div>
-      <p id="capWarning" class="text-error hidden margin-reset"></p><button id="buyBtn" onclick="buyTokens()"
-        disabled="disabled">Enter Amount</button>
+      <div class="input-group"><label>Amount in ETH</label> <input type="number" id="maticAmount" min="0.0003" step="0.0001" placeholder="Min 0.0003 ETH" oninput="calculateTokens()"></div>
+      <div class="input-group"><label>You Will Receive (Approx)</label> <input type="text" id="tokenAmount" disabled="disabled" placeholder="0 AETH"></div>
+      <p id="capWarning" class="text-error hidden margin-reset"></p><button id="buyBtn" onclick="buyTokens()" disabled="disabled">Enter Amount</button>
     </div>
     <div class="text-center margin-top">
       <p><small>Contract: <span id="contractAddr">Checking...</span></small></p>

--- a/smart-contract/config/presale-base-production.json
+++ b/smart-contract/config/presale-base-production.json
@@ -8,11 +8,11 @@
   "rateAethPerEth": "1000000",
   "softCapEth": "5",
   "hardCapEth": "33.333333",
-  "minContributionEth": "0.001",
-  "maxContributionEth": "1",
+  "minContributionEth": "0.0003",
+  "maxContributionEth": "33.333333",
   "startDelaySeconds": "3600",
   "durationSeconds": "1209600",
-  "ownerSmokePurchaseEth": "0.001",
+  "ownerSmokePurchaseEth": "0.0003",
   "fundingAeth": "33333333",
   "tokenPriceEth": "0.000001",
   "status": "values-filled-awaiting-protected-secrets-and-owner-signatures",
@@ -23,6 +23,7 @@
   "notes": [
     "The treasury uses the Base owner/treasury address already recorded in deployment evidence.",
     "The hard cap and rate exactly fund the existing 33,333,333 AETH frontend sale allocation.",
+    "The per-wallet maximum equals the sale hard cap, so a buyer may purchase any remaining capacity without exceeding the global cap.",
     "The 50,000,000 AETH locked in the invalid presale is excluded from this allocation.",
     "A public token sale should not be opened until applicable legal and disclosure requirements have been reviewed."
   ]

--- a/smart-contract/scripts/start-presale-local.mjs
+++ b/smart-contract/scripts/start-presale-local.mjs
@@ -10,8 +10,8 @@ const PRIVATE_KEY =
 const RATE = 1_000_000n;
 const SOFT_CAP = ethers.parseEther("5");
 const HARD_CAP = ethers.parseEther("33.333333");
-const MIN_CONTRIBUTION = ethers.parseEther("0.0003");
-const MAX_CONTRIBUTION = HARD_CAP;
+const MIN_CONTRIBUTION = ethers.parseEther("0.001");
+const MAX_CONTRIBUTION = ethers.parseEther("1");
 const START_DELAY = 60;
 const DURATION = 14 * 24 * 60 * 60;
 

--- a/smart-contract/scripts/start-presale-local.mjs
+++ b/smart-contract/scripts/start-presale-local.mjs
@@ -10,8 +10,8 @@ const PRIVATE_KEY =
 const RATE = 1_000_000n;
 const SOFT_CAP = ethers.parseEther("5");
 const HARD_CAP = ethers.parseEther("33.333333");
-const MIN_CONTRIBUTION = ethers.parseEther("0.001");
-const MAX_CONTRIBUTION = ethers.parseEther("1");
+const MIN_CONTRIBUTION = ethers.parseEther("0.0003");
+const MAX_CONTRIBUTION = HARD_CAP;
 const START_DELAY = 60;
 const DURATION = 14 * 24 * 60 * 60;
 


### PR DESCRIPTION
## What changed

- lowers the minimum purchase from 0.001 ETH to 0.0003 ETH
- raises the cumulative per-wallet maximum to the 33.333333 ETH sale hard cap, allowing a buyer to purchase any remaining capacity
- keeps the global hard cap and exact 33,333,333 AETH inventory unchanged
- aligns the disabled frontend and local production-like simulator

## Why

The prior 1 ETH value was a per-wallet ceiling and did not match the intended sale terms. The contract requires a numeric per-wallet maximum, so matching it to the global hard cap removes the practical wallet restriction without allowing the sale to collect more than its total cap.

## Safety

This PR does not deploy a contract, send a Base transaction, or enable public purchases. The frontend remains disabled pending deployment and review.