### PR TITLE
Fix verification-only production secret scope

### DIFF
--- a/.github/workflows/verify-existing-base-presale.yml
+++ b/.github/workflows/verify-existing-base-presale.yml
@@ -18,10 +18,11 @@ concurrency:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 20
     env:
-      BASE_RPC_URL: ${{ secrets.BASE_RPC_URL }}
-      ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+      BASE_RPC_URL: ${{ secrets.BASE_RPC_URL || 'https://mainnet.base.org' }}
+      ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY || secrets.BASESCAN_API_KEY }}
       NODE_OPTIONS: --max-old-space-size=5120
     steps:
       - name: Require explicit verification authorization


### PR DESCRIPTION
Attaches the verification-only job to the existing production environment and uses the same explorer-key fallback/public Base RPC fallback as the proven deployment workflow. No transaction-capable credential or command is added.