### PR TITLE
Use Base mainnet environment for verification-only workflow

### DIFF
--- a/.github/workflows/verify-existing-base-presale.yml
+++ b/.github/workflows/verify-existing-base-presale.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   verify:
     runs-on: ubuntu-latest
-    environment: production
+    environment: base-mainnet-production
     timeout-minutes: 20
     env:
       BASE_RPC_URL: ${{ secrets.BASE_RPC_URL || 'https://mainnet.base.org' }}


### PR DESCRIPTION
Uses the exact `base-mainnet-production` environment already proven by the live deployment workflow. No other logic changes and no transaction capability is added.