### PR TITLE
Fix Etherscan V2 POST chain ID

### DIFF
--- a/smart-contract/scripts/verify-basescan-v2.mjs
+++ b/smart-contract/scripts/verify-basescan-v2.mjs
@@ -101,7 +101,7 @@ async function etherscanRequest(values, method = "POST") {
 
   const response = method === "GET"
     ? await fetch(`${API_URL}?${params.toString()}`, { method: "GET" })
-    : await fetch(API_URL, {
+    : await fetch(`${API_URL}?chainid=${CHAIN_ID}`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
         body: params


### PR DESCRIPTION
Adds the required Base `chainid=8453` query parameter to Etherscan V2 POST requests. The existing form body remains unchanged. Verification-only; no transaction.