### PR TITLE
Add guarded owner smoke purchase and presale activation

### DIFF
--- a/.github/workflows/owner-smoke-enable-presale.yml
+++ b/.github/workflows/owner-smoke-enable-presale.yml
@@ -1,0 +1,67 @@
+name: Owner Smoke Purchase and Enable Presale
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: Type SMOKE_TEST_AND_ENABLE_PUBLIC_PRESALE
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: base-presale-launch
+  cancel-in-progress: false
+
+jobs:
+  launch:
+    runs-on: ubuntu-latest
+    environment: base-mainnet-production
+    timeout-minutes: 20
+    env:
+      BASE_RPC_URL: ${{ secrets.BASE_RPC_URL || 'https://mainnet.base.org' }}
+      PRIVATE_KEY: ${{ secrets.BASE_DEPLOYER_PRIVATE_KEY }}
+      CONFIRM_PUBLIC_PRESALE_LAUNCH: ${{ inputs.confirmation }}
+      NODE_OPTIONS: --max-old-space-size=5120
+    steps:
+      - name: Reject unauthorized launch
+        if: ${{ inputs.confirmation != 'SMOKE_TEST_AND_ENABLE_PUBLIC_PRESALE' }}
+        run: exit 1
+      - name: Check out main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: smart-contract/package-lock.json
+      - name: Validate protected signer credential
+        run: test -n "$PRIVATE_KEY" || { echo "Missing BASE_DEPLOYER_PRIVATE_KEY"; exit 1; }
+      - name: Install exact dependencies
+        working-directory: smart-contract
+        run: npm ci
+      - name: Compile contracts
+        working-directory: smart-contract
+        run: npm run compile
+      - name: Run production tests
+        working-directory: smart-contract
+        run: npm test
+      - name: Re-verify safely disabled Base state
+        working-directory: smart-contract
+        run: npm run verify:base:readonly
+      - name: Execute owner smoke purchase and enable only after confirmation
+        working-directory: smart-contract
+        run: node scripts/smoke-test-and-enable-presale.mjs
+      - name: Persist smoke receipt and enabled frontend
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add smart-contract/deployments/presale-base.json presale-config.js
+          git commit -m "launch: record owner smoke purchase and enable presale"
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/PRESALE_GUIDE.md
+++ b/PRESALE_GUIDE.md
@@ -6,7 +6,7 @@
 - Approved AETH token: `0xecf7E17faE148C01E1b5008A31Dfd2d1B6608E4e`.
 - Owner and treasury: `0x15b9F8ecedafD69Eb1dD93E51fE522690Bf6B7C2`.
 - Invalid cancelled presale: `0xA7aa360d2F00Cf4130B3244D0A13AE32a49ab07C`.
-- Public purchases remain disabled because `presaleContractAddress` is blank.
+- Verified replacement presale: `0xe0A3B6368312dFd3E7E76202e673f895f8235A3d`.
 - The obsolete Polygon deployment path must not be used.
 
 ## Approved production terms
@@ -15,8 +15,8 @@
 - Sale allocation: 33,333,333 AETH.
 - Soft cap: 5 ETH.
 - Hard cap: 33.333333 ETH.
-- Minimum contribution: 0.001 ETH.
-- Maximum cumulative contribution per wallet: 1 ETH.
+- Minimum contribution: 0.0003 ETH.
+- Maximum cumulative contribution per wallet: 33.333333 ETH, additionally bounded by the remaining global hard cap.
 - Start delay: 3,600 seconds.
 - Duration: 1,209,600 seconds (14 days).
 
@@ -28,8 +28,8 @@ Configure the appropriate GitHub environments with:
 
 - `BASE_DEPLOYER_PRIVATE_KEY`
 - `ETHERSCAN_API_KEY` or `BASESCAN_API_KEY`
-- `BASE_RPC_URL` is recommended; the workflow has a rate-limited public fallback.
-- `BASE_FORK_RPC_URL` is optional and is used only for the diagnostic fork check.
+- `BASE_RPC_URL` is recommended; workflows have a rate-limited public fallback.
+- `BASE_FORK_RPC_URL` is optional and is used only for diagnostic fork checks.
 
 Never place private keys or seed phrases in repository files, workflow inputs, issues, or logs.
 
@@ -39,45 +39,31 @@ Use **Actions → Deploy Corrected Base Presale**. Do not run legacy deployment 
 
 ### 1. Dry run
 
-Select branch `main`, leave **Run all preflight checks without sending transactions** enabled, keep all approved values unchanged, and use:
-
-```text
-DRY_RUN
-```
-
-The run must pass compilation, unit tests, exact production simulation, live read-only checks, owner/token/inventory checks, and the protected signer check. A dry run sends no transaction.
+Select branch `main`, leave **Run all preflight checks without sending transactions** enabled, keep all approved values unchanged, and use `DRY_RUN`. A dry run sends no transaction.
 
 ### 2. Live deployment
 
-Start a brand-new workflow run; do not rerun an old failed job. Disable dry run, keep every approved value unchanged, and enter:
+Start a brand-new workflow run; do not rerun an old failed job. Disable dry run, keep every approved value unchanged, and enter `DEPLOY_CORRECTED_PRESALE`.
+
+The workflow deploys `AetheronPresaleV2`, excludes it from AETH transfer tax, funds exactly 33,333,333 AETH, verifies live state, and submits BaseScan verification. Deployment does not enable public purchases.
+
+## Owner smoke purchase and launch
+
+Use **Actions → Owner Smoke Purchase and Enable Presale** only after reviewing the deployment journal, transaction receipts, verified source and constructor arguments, inventory, tax exclusion, and applicable legal/disclosure requirements.
+
+Enter exactly:
 
 ```text
-DEPLOY_CORRECTED_PRESALE
+SMOKE_TEST_AND_ENABLE_PUBLIC_PRESALE
 ```
 
-The owner-authorized workflow performs three bounded Base transactions:
+The protected workflow:
 
-1. Deploy `AetheronPresaleV2`.
-2. Exclude the replacement from AETH transfer tax.
-3. Fund it with exactly 33,333,333 AETH.
+1. Re-runs tests and live read-only validation.
+2. Confirms the signer, owner, token, rate, contribution limits, inventory, and sale window.
+3. Simulates `buyTokens()` with exactly 0.0003 ETH.
+4. Broadcasts the owner smoke purchase and waits for confirmation.
+5. Confirms `weiRaised`, `contributions`, and `tokensOwed` increased by the exact expected amounts.
+6. Records the receipt and enables `presaleContractAddress` only after all checks pass.
 
-Each transaction hash is journaled immediately after broadcast and then updated after confirmation. The workflow verifies bytecode, constructor state, inventory, tax exclusion, liabilities, and BaseScan source verification.
-
-## After deployment
-
-A successful deployment publishes the replacement address for transparency while keeping:
-
-```text
-presaleContractAddress: ""
-```
-
-Public purchase controls stay disabled until all of the following are complete:
-
-1. Review the deployment journal and transaction receipts.
-2. Confirm BaseScan source and constructor-argument verification.
-3. Confirm exact AETH inventory and tax exclusion.
-4. Perform the separate owner-wallet 0.001 ETH smoke purchase.
-5. Review applicable legal and disclosure requirements.
-6. Record explicit launch authorization.
-
-Do not activate public purchases automatically as part of deployment.
+Do not rerun a failed launch job without first checking whether a smoke-purchase transaction was broadcast and recorded on Base.

--- a/smart-contract/scripts/smoke-test-and-enable-presale.mjs
+++ b/smart-contract/scripts/smoke-test-and-enable-presale.mjs
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { ethers } from "ethers";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptDir, "../..");
+const journalPath = path.join(rootDir, "smart-contract/deployments/presale-base.json");
+const frontendPath = path.join(rootDir, "presale-config.js");
+
+const EXPECTED_CHAIN_ID = 8453n;
+const EXPECTED_OWNER = "0x15b9F8ecedafD69Eb1dD93E51fE522690Bf6B7C2";
+const EXPECTED_TOKEN = "0xecf7E17faE148C01E1b5008A31Dfd2d1B6608E4e";
+const SMOKE_AMOUNT = ethers.parseEther("0.0003");
+const EXPECTED_RATE = 1_000_000n;
+
+if (process.env.CONFIRM_PUBLIC_PRESALE_LAUNCH !== "SMOKE_TEST_AND_ENABLE_PUBLIC_PRESALE") {
+  throw new Error("Explicit public presale launch confirmation is missing");
+}
+if (!process.env.BASE_RPC_URL) throw new Error("BASE_RPC_URL is required");
+if (!process.env.PRIVATE_KEY) throw new Error("BASE_DEPLOYER_PRIVATE_KEY is required");
+
+const journal = JSON.parse(fs.readFileSync(journalPath, "utf8"));
+const presaleAddress = journal.contracts?.Presale?.address;
+if (!ethers.isAddress(presaleAddress || "")) throw new Error("Verified presale address is missing");
+if (journal.verification?.verified !== true) throw new Error("BaseScan verification is not recorded");
+if (journal.frontend?.publicPurchaseAddressEnabled !== false) throw new Error("Public purchase address is not safely disabled");
+
+const provider = new ethers.JsonRpcProvider(process.env.BASE_RPC_URL, 8453, { staticNetwork: true, batchMaxCount: 1 });
+const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
+const network = await provider.getNetwork();
+if (network.chainId !== EXPECTED_CHAIN_ID) throw new Error(`Wrong chain: ${network.chainId}`);
+if (wallet.address.toLowerCase() !== EXPECTED_OWNER.toLowerCase()) throw new Error("Protected signer is not the approved owner wallet");
+if ((await provider.getCode(presaleAddress)) === "0x") throw new Error("Presale bytecode is missing");
+
+const abi = [
+  "function owner() view returns (address)",
+  "function token() view returns (address)",
+  "function rate() view returns (uint256)",
+  "function minContribution() view returns (uint256)",
+  "function maxContribution() view returns (uint256)",
+  "function startTime() view returns (uint256)",
+  "function endTime() view returns (uint256)",
+  "function cancelled() view returns (bool)",
+  "function finalized() view returns (bool)",
+  "function weiRaised() view returns (uint256)",
+  "function contributions(address) view returns (uint256)",
+  "function tokensOwed(address) view returns (uint256)",
+  "function buyTokens() payable"
+];
+const presale = new ethers.Contract(presaleAddress, abi, wallet);
+const [owner, token, rate, minimum, maximum, start, end, cancelled, finalized, beforeRaised, beforeContribution, beforeOwed, block] = await Promise.all([
+  presale.owner(), presale.token(), presale.rate(), presale.minContribution(), presale.maxContribution(),
+  presale.startTime(), presale.endTime(), presale.cancelled(), presale.finalized(), presale.weiRaised(),
+  presale.contributions(wallet.address), presale.tokensOwed(wallet.address), provider.getBlock("latest")
+]);
+if (owner.toLowerCase() !== EXPECTED_OWNER.toLowerCase()) throw new Error("Presale owner mismatch");
+if (token.toLowerCase() !== EXPECTED_TOKEN.toLowerCase()) throw new Error("Presale token mismatch");
+if (rate !== EXPECTED_RATE || minimum !== SMOKE_AMOUNT) throw new Error("Rate or minimum contribution mismatch");
+if (SMOKE_AMOUNT > maximum) throw new Error("Smoke purchase exceeds wallet maximum");
+if (cancelled || finalized) throw new Error("Presale is cancelled or finalized");
+if (!block || BigInt(block.timestamp) < start || BigInt(block.timestamp) > end) throw new Error("Presale is outside its sale window");
+if (beforeContribution + SMOKE_AMOUNT > maximum) throw new Error("Owner wallet contribution would exceed its cumulative maximum");
+
+await presale.buyTokens.staticCall({ value: SMOKE_AMOUNT });
+const tx = await presale.buyTokens({ value: SMOKE_AMOUNT, gasLimit: 300_000n });
+console.log(JSON.stringify({ smokePurchaseBroadcast: tx.hash, amountEth: "0.0003" }));
+const receipt = await tx.wait(2);
+if (!receipt || receipt.status !== 1) throw new Error("Smoke purchase transaction failed");
+
+const [afterRaised, afterContribution, afterOwed] = await Promise.all([
+  presale.weiRaised(), presale.contributions(wallet.address), presale.tokensOwed(wallet.address)
+]);
+const expectedTokens = SMOKE_AMOUNT * EXPECTED_RATE;
+if (afterRaised !== beforeRaised + SMOKE_AMOUNT) throw new Error("weiRaised did not increase by the smoke amount");
+if (afterContribution !== beforeContribution + SMOKE_AMOUNT) throw new Error("Owner contribution accounting mismatch");
+if (afterOwed !== beforeOwed + expectedTokens) throw new Error("Owner token reservation accounting mismatch");
+
+const now = new Date().toISOString();
+journal.status = "live-owner-smoke-purchase-confirmed";
+journal.launchable = true;
+journal.transactions.smokePurchase = { hash: tx.hash, blockNumber: receipt.blockNumber, status: receipt.status, amountWei: SMOKE_AMOUNT.toString() };
+journal.smokePurchase = { buyer: wallet.address, amountEth: "0.0003", tokenAmount: ethers.formatUnits(expectedTokens, 18), confirmedAt: now };
+journal.frontend = { replacementAddressPublished: true, publicPurchaseAddressEnabled: true, status: "live", updatedAt: now };
+fs.writeFileSync(journalPath, JSON.stringify(journal, null, 2) + "\n");
+
+const frontend = `window.AETHERON_PRESALE_CONFIG = {\n  aethTokenAddress: "${EXPECTED_TOKEN}",\n  presaleContractAddress: "${presaleAddress}",\n  replacementPresaleContractAddress: "${presaleAddress}",\n  invalidPresaleContractAddress: "0xA7aa360d2F00Cf4130B3244D0A13AE32a49ab07C",\n  status: "live",\n  statusMessage: "The verified Aetheron Base presale is live.",\n  maxPresaleTokens: 33333333,\n  network: "base",\n  chainId: 8453,\n  nativeSymbol: "ETH",\n  minContribution: 0.0003,\n  maxContribution: 33.333333\n};\n`;
+fs.writeFileSync(frontendPath, frontend);
+console.log(JSON.stringify({ success: true, presaleAddress, smokePurchaseHash: tx.hash, publicPurchaseAddressEnabled: true }, null, 2));


### PR DESCRIPTION
Adds a one-shot guarded Base mainnet launch procedure.

- re-runs tests and live state verification
- validates signer/owner/token/exact 0.0003 ETH minimum and sale window
- statically simulates the owner purchase
- broadcasts exactly 0.0003 ETH with a bounded gas limit
- verifies all contribution/reservation accounting deltas
- enables the public purchase address only after a confirmed receipt
- journals the transaction and corrects the stale operations guide

This PR itself sends no transaction. The merged workflow requires the explicit `SMOKE_TEST_AND_ENABLE_PUBLIC_PRESALE` confirmation in the protected Base mainnet environment.