### PR TITLE
fix: reconcile live Base presale state

### DIFF
--- a/smart-contract/deployments/presale-base.json
+++ b/smart-contract/deployments/presale-base.json
@@ -59,10 +59,10 @@
     "reason": "token() did not match the configured Base AETH token"
   },
   "safety": {
-    "frontendEnabled": false,
-    "note": "Deployment, token-tax exclusion, and funding are separate owner transactions. Each completed step is journaled immediately."
+    "frontendEnabled": true,
+    "note": "The verified Base presale passed the owner smoke purchase and the public purchase address is enabled."
   },
-  "updatedAt": "2026-07-18T19:07:11.633Z",
+  "updatedAt": "2026-07-18T21:33:42.406Z",
   "inventory": {
     "tokenUnits": "33333333000000000000000000",
     "tokenAmount": "33333333.0"
@@ -78,8 +78,8 @@
     "maxContributionWei": "33333333000000000000",
     "startTime": "1784405200",
     "endTime": "1785614800",
-    "weiRaised": "0",
-    "tokensReserved": "0",
+    "weiRaised": "300000000000000",
+    "tokensReserved": "300000000000000000000",
     "cancelled": false,
     "finalized": false,
     "taxExcluded": true,

--- a/smart-contract/scripts/smoke-test-and-enable-presale.mjs
+++ b/smart-contract/scripts/smoke-test-and-enable-presale.mjs
@@ -44,6 +44,7 @@ const abi = [
   "function cancelled() view returns (bool)",
   "function finalized() view returns (bool)",
   "function weiRaised() view returns (uint256)",
+  "function tokensReserved() view returns (uint256)",
   "function contributions(address) view returns (uint256)",
   "function tokensOwed(address) view returns (uint256)",
   "function buyTokens() payable"
@@ -68,8 +69,8 @@ console.log(JSON.stringify({ smokePurchaseBroadcast: tx.hash, amountEth: "0.0003
 const receipt = await tx.wait(2);
 if (!receipt || receipt.status !== 1) throw new Error("Smoke purchase transaction failed");
 
-const [afterRaised, afterContribution, afterOwed] = await Promise.all([
-  presale.weiRaised(), presale.contributions(wallet.address), presale.tokensOwed(wallet.address)
+const [afterRaised, afterReserved, afterContribution, afterOwed] = await Promise.all([
+  presale.weiRaised(), presale.tokensReserved(), presale.contributions(wallet.address), presale.tokensOwed(wallet.address)
 ]);
 const expectedTokens = SMOKE_AMOUNT * EXPECTED_RATE;
 if (afterRaised !== beforeRaised + SMOKE_AMOUNT) throw new Error("weiRaised did not increase by the smoke amount");
@@ -79,8 +80,11 @@ if (afterOwed !== beforeOwed + expectedTokens) throw new Error("Owner token rese
 const now = new Date().toISOString();
 journal.status = "live-owner-smoke-purchase-confirmed";
 journal.launchable = true;
+journal.updatedAt = now;
 journal.transactions.smokePurchase = { hash: tx.hash, blockNumber: receipt.blockNumber, status: receipt.status, amountWei: SMOKE_AMOUNT.toString() };
 journal.smokePurchase = { buyer: wallet.address, amountEth: "0.0003", tokenAmount: ethers.formatUnits(expectedTokens, 18), confirmedAt: now };
+journal.safety = { ...journal.safety, frontendEnabled: true, note: "The verified Base presale passed the owner smoke purchase and the public purchase address is enabled." };
+journal.verifiedState = { ...journal.verifiedState, weiRaised: afterRaised.toString(), tokensReserved: afterReserved.toString() };
 journal.frontend = { replacementAddressPublished: true, publicPurchaseAddressEnabled: true, status: "live", updatedAt: now };
 fs.writeFileSync(journalPath, JSON.stringify(journal, null, 2) + "\n");
 

--- a/smart-contract/test/ProductionPresaleConfig.test.js
+++ b/smart-contract/test/ProductionPresaleConfig.test.js
@@ -51,13 +51,18 @@ test("contribution limits and schedule satisfy deployment guards", () => {
   assert.equal(production.ownerSmokePurchaseEth, production.minContributionEth);
 });
 
-test("disabled frontend config matches the approved Base terms", () => {
+test("frontend config matches the approved Base terms and recorded launch state", () => {
   assert.match(rootFrontendSource, new RegExp(`aethTokenAddress: ["']${production.tokenAddress}["']`));
-  assert.match(rootFrontendSource, /presaleContractAddress:\s*["']["']/);
-  assert.match(
-    rootFrontendSource,
-    /status:\s*["'](?:disabled-awaiting-replacement-deployment|disabled-awaiting-basescan-and-owner-smoke-test|verified-disabled-awaiting-owner-smoke-test)["']/
-  );
+  if (deployment.launchable) {
+    assert.match(rootFrontendSource, new RegExp(`presaleContractAddress: ["']${deployment.contracts.Presale.address}["']`));
+    assert.match(rootFrontendSource, /status:\s*["']live["']/);
+  } else {
+    assert.match(rootFrontendSource, /presaleContractAddress:\s*["']["']/);
+    assert.match(
+      rootFrontendSource,
+      /status:\s*["'](?:disabled-awaiting-replacement-deployment|disabled-awaiting-basescan-and-owner-smoke-test|verified-disabled-awaiting-owner-smoke-test)["']/
+    );
+  }
   assert.match(rootFrontendSource, /network:\s*["']base["']/);
   assert.match(rootFrontendSource, /chainId:\s*8453/);
   assert.match(rootFrontendSource, new RegExp(`minContribution:\\s*${production.minContributionEth.replace(".", "\\.")}`));
@@ -74,6 +79,21 @@ test("deployment journal preserves accounting or a recoverable non-launchable st
     assert.equal(nominal - locked, maximumAccessible);
     assert.ok(BigInt(production.saleAllocationAeth) <= maximumAccessible);
     assert.equal(locked, 50_000_000n);
+    return;
+  }
+
+  if (deployment.launchable) {
+    assert.equal(deployment.safety?.frontendEnabled, true);
+    assert.equal(deployment.frontend?.publicPurchaseAddressEnabled, true);
+    assert.equal(deployment.frontend?.status, "live");
+    assert.ok(ethers.isAddress(deployment.contracts?.Presale?.address));
+    assert.ok(isTransactionHash(deployment.transactions?.smokePurchase?.hash));
+    assert.equal(BigInt(deployment.transactions.smokePurchase.amountWei), ethers.parseEther(production.ownerSmokePurchaseEth));
+    assert.equal(BigInt(deployment.verifiedState?.weiRaised), ethers.parseEther(production.ownerSmokePurchaseEth));
+    assert.equal(
+      BigInt(deployment.verifiedState?.tokensReserved),
+      ethers.parseEther(production.ownerSmokePurchaseEth) * BigInt(production.rateAethPerEth)
+    );
     return;
   }
 


### PR DESCRIPTION
## What changed

- Reconciles the Base deployment journal with the confirmed owner smoke purchase.
- Marks the frontend safety flag enabled.
- Records `0.0003 ETH` raised and `300 AETH` reserved.
- Updates the smoke-launch script to persist `updatedAt`, the enabled safety state, `weiRaised`, and total `tokensReserved` after future launches.

## Why

The public frontend was correctly enabled and the smoke transaction succeeded, but two cached journal fields still described the pre-launch state. This removes that internal inconsistency without broadcasting any additional transaction.

## Impact

No contract call and no second purchase are performed by this PR. The live presale address, minimum contribution, wallet maximum, and confirmed transaction remain unchanged.

## Validation

Protected presale CI checks should compile, test, and verify the guarded deployment paths before merge.