### PR TITLE
deploy: publish verified Base presale to aetrs.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+aetrs.com

--- a/presale-config.js
+++ b/presale-config.js
@@ -1,0 +1,14 @@
+window.AETHERON_PRESALE_CONFIG = {
+  aethTokenAddress: "0xecf7E17faE148C01E1b5008A31Dfd2d1B6608E4e",
+  presaleContractAddress: "0xe0A3B6368312dFd3E7E76202e673f895f8235A3d",
+  replacementPresaleContractAddress: "0xe0A3B6368312dFd3E7E76202e673f895f8235A3d",
+  invalidPresaleContractAddress: "0xA7aa360d2F00Cf4130B3244D0A13AE32a49ab07C",
+  status: "live",
+  statusMessage: "The verified Aetheron Base presale is live.",
+  maxPresaleTokens: 33333333,
+  network: "base",
+  chainId: 8453,
+  nativeSymbol: "ETH",
+  minContribution: 0.0003,
+  maxContribution: 33.333333
+};

--- a/presale.html
+++ b/presale.html
@@ -5,173 +5,37 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta http-equiv="Content-Security-Policy"
-    content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; connect-src 'self' https://api.coingecko.com https://api.coinmarketcap.com https://polygon-rpc.com https://rpc-mainnet.matic.network https://etherscan.io https://api.etherscan.io https://api.polygonscan.com https://polygonscan.com https://api.dexscreener.com https://dexscreener.com https://api.github.com https://github.com https://api.telegram.org https://telegram.org https://discord.com https://discordapp.com https://api.discord.com https://cdn.discordapp.com; frame-src 'self' https://www.youtube.com https://youtube.com https://player.vimeo.com https://vimeo.com;">
-  <title>Aetheron Presale - Join Early</title>
+    content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; connect-src 'self' https://api.coingecko.com https://api.coinmarketcap.com https://polygon-rpc.com https://rpc-mainnet.matic.network https://etherscan.io https://api.etherscan.io https://api.polygonscan.com https://polygonscan.com https://api.dexscreener.com https://dexscreener.com https://api.github.com https://github.com https://api.telegram.org https://telegram.org https://discord.com https://discordapp.com https://api.discord.com https://cdn.discordapp.com https://mainnet.base.org https://base.drpc.org https://basescan.org; frame-src 'self' https://www.youtube.com https://youtube.com https://player.vimeo.com https://vimeo.com;">
+  <title>Aetheron Presale on Base | Join Early</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet"
     crossorigin="anonymous" referrerpolicy="no-referrer">
   <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js" defer></script>
   <style>
-    .hidden {
-      display: none;
-    }
-
-    .text-center {
-      text-align: center;
-    }
-
-    .text-muted {
-      color: #64748b;
-    }
-
-    .text-error {
-      color: #ef4444;
-    }
-
-    .margin-reset {
-      margin: 0 0 0.75rem 0;
-    }
-
-    .margin-top {
-      margin-top: 1rem;
-    }
-
-    body {
-      font-family: Inter, sans-serif;
-      background: linear-gradient(135deg, var(--primary) 0, var(--secondary) 100%);
-      min-height: 100vh;
-      color: var(--dark);
-      margin: 0;
-      padding: 20px
-    }
-
-    .container {
-      max-width: 800px;
-      margin: 2rem auto;
-      background: rgba(255, 255, 255, .95);
-      border-radius: 24px;
-      padding: 3rem;
-      box-shadow: 0 10px 25px rgba(0, 0, 0, .2)
-    }
-
-    .header {
-      text-align: center;
-      margin-bottom: 2rem
-    }
-
-    .header h1 {
-      background: linear-gradient(135deg, var(--primary), var(--secondary));
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      font-size: 2.5rem;
-      margin-bottom: 1rem
-    }
-
-    .card {
-      background: #fff;
-      border-radius: 16px;
-      padding: 2rem;
-      margin-bottom: 1.5rem;
-      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, .1);
-      border: 1px solid #e5e7eb
-    }
-
-    .stats-grid {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-      gap: 1.5rem;
-      margin-bottom: 2rem
-    }
-
-    .stat-box {
-      background: #f8fafc;
-      padding: 1.5rem;
-      border-radius: 12px;
-      text-align: center
-    }
-
-    .stat-value {
-      font-size: 1.5rem;
-      font-weight: 700;
-      color: var(--primary)
-    }
-
-    .input-group {
-      margin-bottom: 1rem
-    }
-
-    .input-group label {
-      display: block;
-      margin-bottom: .5rem;
-      font-weight: 600
-    }
-
-    .input-group input {
-      width: 100%;
-      padding: 1rem;
-      border: 2px solid #e2e8f0;
-      border-radius: 12px;
-      font-size: 1.1rem;
-      transition: border-color .3s
-    }
-
-    .input-group input:focus {
-      outline: 0;
-      border-color: var(--primary)
-    }
-
-    button {
-      width: 100%;
-      padding: 1rem;
-      background: linear-gradient(135deg, var(--primary), var(--secondary));
-      color: #fff;
-      border: none;
-      border-radius: 12px;
-      font-size: 1.1rem;
-      font-weight: 600;
-      cursor: pointer;
-      transition: transform .2s, opacity .2s
-    }
-
-    button:hover {
-      transform: translateY(-2px);
-      opacity: .95
-    }
-
-    button:disabled {
-      background: #cbd5e1;
-      cursor: not-allowed;
-      transform: none
-    }
-
-    .progress-bar {
-      width: 100%;
-      height: 12px;
-      background: #e2e8f0;
-      border-radius: 6px;
-      margin: 1rem 0;
-      overflow: hidden
-    }
-
-    .progress-fill {
-      height: 100%;
-      background: var(--success);
-      width: 0%;
-      transition: width .5s ease
-    }
-
-    .nav-back {
-      display: inline-block;
-      margin-bottom: 1rem;
-      color: #fff;
-      text-decoration: none;
-      font-weight: 500
-    }
-
-    #wallet-status {
-      text-align: center;
-      margin-bottom: 1rem;
-      font-weight: 500
-    }
+    .hidden { display: none; }
+    .text-center { text-align: center; }
+    .text-muted { color: #64748b; }
+    .text-error { color: #ef4444; }
+    .margin-reset { margin: 0 0 0.75rem 0; }
+    .margin-top { margin-top: 1rem; }
+    body { font-family: Inter, sans-serif; background: linear-gradient(135deg, var(--primary) 0, var(--secondary) 100%); min-height: 100vh; color: var(--dark); margin: 0; padding: 20px }
+    .container { max-width: 800px; margin: 2rem auto; background: rgba(255, 255, 255, .95); border-radius: 24px; padding: 3rem; box-shadow: 0 10px 25px rgba(0, 0, 0, .2) }
+    .header { text-align: center; margin-bottom: 2rem }
+    .header h1 { background: linear-gradient(135deg, var(--primary), var(--secondary)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; font-size: 2.5rem; margin-bottom: 1rem }
+    .card { background: #fff; border-radius: 16px; padding: 2rem; margin-bottom: 1.5rem; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, .1); border: 1px solid #e5e7eb }
+    .stats-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1.5rem; margin-bottom: 2rem }
+    .stat-box { background: #f8fafc; padding: 1.5rem; border-radius: 12px; text-align: center }
+    .stat-value { font-size: 1.5rem; font-weight: 700; color: var(--primary) }
+    .input-group { margin-bottom: 1rem }
+    .input-group label { display: block; margin-bottom: .5rem; font-weight: 600 }
+    .input-group input { width: 100%; padding: 1rem; border: 2px solid #e2e8f0; border-radius: 12px; font-size: 1.1rem; transition: border-color .3s }
+    .input-group input:focus { outline: 0; border-color: var(--primary) }
+    button { width: 100%; padding: 1rem; background: linear-gradient(135deg, var(--primary), var(--secondary)); color: #fff; border: none; border-radius: 12px; font-size: 1.1rem; font-weight: 600; cursor: pointer; transition: transform .2s, opacity .2s }
+    button:hover { transform: translateY(-2px); opacity: .95 }
+    button:disabled { background: #cbd5e1; cursor: not-allowed; transform: none }
+    .progress-bar { width: 100%; height: 12px; background: #e2e8f0; border-radius: 6px; margin: 1rem 0; overflow: hidden }
+    .progress-fill { height: 100%; background: var(--success); width: 0%; transition: width .5s ease }
+    .nav-back { display: inline-block; margin-bottom: 1rem; color: #fff; text-decoration: none; font-weight: 500 }
+    #wallet-status { text-align: center; margin-bottom: 1rem; font-weight: 500 }
   </style>
   <link rel="stylesheet" href="shared-mobile-polish.css?v=1.3.0">
 </head>
@@ -182,46 +46,32 @@
       <h1>Aetheron Community Presale</h1>
       <p>Support the liquidity launch and get AETH tokens early!</p>
     </div>
-    <div id="wallet-status"><button id="connectBtn" onclick="connectWallet()">Connect Wallet</button> <span
-        id="walletAddress" class="hidden"></span></div>
+    <div id="wallet-status"><button id="connectBtn" onclick="connectWallet()">Connect Wallet</button> <span id="walletAddress" class="hidden"></span></div>
     <div class="card">
       <h3>Presale Status</h3>
       <div class="stats-grid">
-        <div class="stat-box">
-          <div class="label">Rate</div>
-          <div class="stat-value" id="rateDisplay">1 MATIC = 1000 AETH</div>
-        </div>
-        <div class="stat-box">
-          <div class="label">Total Raised</div>
-          <div class="stat-value" id="raisedDisplay">0 MATIC</div>
-        </div>
-        <div class="stat-box">
-          <div class="label">Max Tokens</div>
-          <div class="stat-value" id="maxTokensDisplay">40,000,000 AETH</div>
-        </div>
-        <div class="stat-box">
-          <div class="label">Max Raise</div>
-          <div class="stat-value" id="maxRaiseDisplay">$25,000</div>
-        </div>
+        <div class="stat-box"><div class="label">Rate</div><div class="stat-value" id="rateDisplay">1 ETH = 1,000,000 AETH</div></div>
+        <div class="stat-box"><div class="label">Total Raised</div><div class="stat-value" id="raisedDisplay">Loading...</div></div>
+        <div class="stat-box"><div class="label">Available Tokens</div><div class="stat-value" id="maxTokensDisplay">Loading...</div></div>
+        <div class="stat-box"><div class="label">Hard Cap</div><div class="stat-value" id="maxRaiseDisplay">33.333333 ETH</div></div>
       </div>
-      <div class="progress-bar">
-        <div class="progress-fill" id="progressBar"></div>
-      </div>
-      <p class="text-center text-muted" id="capStatus">Goal: Raise liquidity for QuickSwap Listing</p>
+      <div class="progress-bar"><div class="progress-fill" id="progressBar"></div></div>
+      <p class="text-center text-muted" id="capStatus">Checking verified Base presale status...</p>
+      <p class="text-center" id="refundSection" style="display:none;margin-top:10px;"><button onclick="claimRefund()" style="background:#ef4444;color:#fff;padding:8px 16px;border-radius:8px;border:none;cursor:pointer;">Claim Refund</button></p>
+      <p class="text-center" id="withdrawSection" style="display:none;margin-top:10px;"><button onclick="withdrawToTreasury()" style="background:linear-gradient(135deg,#6366f1,#8b5cf6);color:#fff;padding:8px 16px;border-radius:8px;border:none;cursor:pointer;">Withdraw Funds to Treasury</button></p>
     </div>
     <div class="card">
       <h3>Buy AETH</h3>
-      <div class="input-group"><label>Amount in MATIC</label> <input type="number" id="maticAmount"
-          placeholder="Min 1 MATIC" oninput="calculateTokens()"></div>
-      <div class="input-group"><label>You Will Receive (Approx)</label> <input type="text" id="tokenAmount"
-          disabled="disabled" placeholder="0 AETH"></div>
-      <p id="capWarning" class="text-error hidden margin-reset"></p><button id="buyBtn" onclick="buyTokens()"
-        disabled="disabled">Enter Amount</button>
+      <div class="input-group"><label>Amount in ETH</label> <input type="number" id="maticAmount" min="0.0003" max="33.333333" step="0.0001" placeholder="Min 0.0003 ETH" oninput="calculateTokens()"></div>
+      <div class="input-group"><label>You Will Receive (Approx)</label> <input type="text" id="tokenAmount" disabled="disabled" placeholder="0 AETH"></div>
+      <p id="capWarning" class="text-error hidden margin-reset"></p><button id="buyBtn" onclick="buyTokens()" disabled="disabled">Connect Wallet</button>
     </div>
     <div class="text-center margin-top">
-      <p><small>Contract: <span id="contractAddr">...</span></small></p>
+      <p><small>Verified Base contract: <span id="contractAddr">Checking...</span></small></p>
+      <p class="text-muted" style="font-size:12px;margin-top:5px;">Purchases use ETH on Base. Always verify the contract address before confirming.</p>
     </div>
   </div>
+  <script src="presale-config.js"></script>
   <script src="presale.js"></script>
   <script src="global-announcements.js"></script>
 </body>

--- a/presale.js
+++ b/presale.js
@@ -1,181 +1,243 @@
-// Presale Logic
+// Aetheron Base Presale Logic
 let provider, signer, presaleContract;
-const PRESALE_CONTRACT_ADDRESS = "REPLACE_WITH_DEPLOYED_ADDRESS"; // You must update this after deployment
+
+const BASE_NETWORK = {
+    chainId: "0x2105",
+    chainName: "Base Mainnet",
+    nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
+    rpcUrls: ["https://mainnet.base.org", "https://base.drpc.org"],
+    blockExplorerUrls: ["https://basescan.org"]
+};
+
+const PRESALE_CONFIG = window.AETHERON_PRESALE_CONFIG || {};
+const AETH_TOKEN_ADDRESS = PRESALE_CONFIG.aethTokenAddress || "";
+const PRESALE_CONTRACT_ADDRESS = PRESALE_CONFIG.presaleContractAddress || "";
+const MAX_PRESALE_TOKENS = PRESALE_CONFIG.maxPresaleTokens || 33333333;
+const CURRENT_CHAIN_ID = BASE_NETWORK.chainId;
+
 const PRESALE_ABI = [
     "function buyTokens() public payable",
     "function rate() public view returns (uint256)",
     "function weiRaised() public view returns (uint256)",
-    "event TokensPurchased(address indexed purchaser, uint256 value, uint256 amount)"
+    "function tokensReserved() public view returns (uint256)",
+    "function token() public view returns (address)",
+    "function softCap() public view returns (uint256)",
+    "function hardCap() public view returns (uint256)",
+    "function minContribution() public view returns (uint256)",
+    "function maxContribution() public view returns (uint256)",
+    "function startTime() public view returns (uint256)",
+    "function endTime() public view returns (uint256)",
+    "function finalized() public view returns (bool)",
+    "function cancelled() public view returns (bool)",
+    "function contributions(address) public view returns (uint256)",
+    "function claimRefund() external",
+    "function withdrawFunds() external"
 ];
 
-let currentRate = 1000;
-let totalRaisedMatic = 0;
+const ERC20_ABI = [
+    "function balanceOf(address) view returns (uint256)",
+    "function decimals() view returns (uint8)"
+];
 
-const MAX_PRESALE_TOKENS = 40000000;
-const MAX_TOTAL_USD = 25000;
-const MATIC_USD = 0.75;
+let currentRate = 1000000;
+let totalRaisedETH = 0;
+let hardCapETH = 0;
+let minContributionETH = 0.0003;
+let maxContributionETH = 33.333333;
+let userContributionETH = 0;
+let availablePurchaseTokens = 0;
+let presaleIsLive = false;
 
-function getMaxMaticByUsd() {
-    return MAX_TOTAL_USD / MATIC_USD;
+function getElement(id) { return document.getElementById(id); }
+function setText(id, value) { const element = getElement(id); if (element) element.innerText = value; }
+function setHtml(id, value) { const element = getElement(id); if (element) element.innerHTML = value; }
+function isAddressConfigured(address) { return /^0x[a-fA-F0-9]{40}$/.test(address) && address !== "0x0000000000000000000000000000000000000000"; }
+function isPresaleConfigured() { return PRESALE_CONFIG.status === "live" && isAddressConfigured(PRESALE_CONTRACT_ADDRESS) && isAddressConfigured(AETH_TOKEN_ADDRESS); }
+function formatNumber(value, decimals = 2) { return Number(value).toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals }); }
+
+function setPurchaseControlsEnabled(enabled, label) {
+    const buyBtn = getElement("buyBtn");
+    const amountInput = getElement("maticAmount");
+    if (buyBtn) { buyBtn.disabled = !enabled; if (label) buyBtn.innerText = label; }
+    if (amountInput) amountInput.disabled = !enabled;
 }
 
-function getMaxMaticByTokens(rate) {
-    return MAX_PRESALE_TOKENS / rate;
+function setPresaleUnavailable(message) {
+    presaleContract = null;
+    presaleIsLive = false;
+    setText("contractAddr", isAddressConfigured(PRESALE_CONTRACT_ADDRESS) ? PRESALE_CONTRACT_ADDRESS : "Not configured");
+    setHtml("capStatus", `<span style="color:#ef4444;">${message}</span>`);
+    setPurchaseControlsEnabled(false, "Unavailable");
 }
 
-function getEffectiveMaticCap(rate) {
-    return Math.min(getMaxMaticByUsd(), getMaxMaticByTokens(rate));
+function validatePurchaseAmount(amount) {
+    if (!Number.isFinite(amount) || amount <= 0) return "Enter a valid contribution amount.";
+    if (amount < minContributionETH) return `Minimum contribution is ${formatNumber(minContributionETH, 6)} ETH.`;
+    const walletRemaining = Math.max(maxContributionETH - userContributionETH, 0);
+    if (amount > walletRemaining) return `Wallet contribution limit remaining: ${formatNumber(walletRemaining, 6)} ETH.`;
+    const hardCapRemaining = Math.max(hardCapETH - totalRaisedETH, 0);
+    if (amount > hardCapRemaining) return `Hard-cap capacity remaining: ${formatNumber(hardCapRemaining, 6)} ETH.`;
+    if (amount * currentRate > availablePurchaseTokens) return `Only ${formatNumber(availablePurchaseTokens, 2)} AETH remain available.`;
+    return null;
 }
 
-function formatNumber(value, decimals = 2) {
-    return Number(value).toLocaleString(undefined, {
-        minimumFractionDigits: decimals,
-        maximumFractionDigits: decimals
-    });
+async function ensureNetwork() {
+    if (!window.ethereum) throw new Error("No Ethereum wallet detected.");
+    const chainId = await window.ethereum.request({ method: "eth_chainId" });
+    if (chainId.toLowerCase() === CURRENT_CHAIN_ID) return;
+    try {
+        await window.ethereum.request({ method: "wallet_switchEthereumChain", params: [{ chainId: CURRENT_CHAIN_ID }] });
+    } catch (error) {
+        if (error.code !== 4902) throw error;
+        await window.ethereum.request({ method: "wallet_addEthereumChain", params: [BASE_NETWORK] });
+    }
 }
 
 async function connectWallet() {
-    if (window.ethereum) {
-        try {
-            provider = new ethers.providers.Web3Provider(window.ethereum);
-            await provider.send("eth_requestAccounts", []);
-            signer = provider.getSigner();
-            const address = await signer.getAddress();
-            
-            document.getElementById('connectBtn').style.display = 'none';
-            document.getElementById('walletAddress').style.display = 'inline-block';
-            document.getElementById('walletAddress').innerText = `Connected: ${address.substring(0,6)}...${address.substring(38)}`;
-            document.getElementById('buyBtn').disabled = false;
-            
-            // Initialize Contract
-            if (PRESALE_CONTRACT_ADDRESS !== "REPLACE_WITH_DEPLOYED_ADDRESS") {
-                presaleContract = new ethers.Contract(PRESALE_CONTRACT_ADDRESS, PRESALE_ABI, provider);
-                document.getElementById('contractAddr').innerText = PRESALE_CONTRACT_ADDRESS;
-                loadPresaleData();
-            } else {
-                alert("Presale contract address not set yet. Please check back later.");
-            }
-
-        } catch (error) {
-            console.error("Connection failed", error);
-        }
-    } else {
-        alert("Please install MetaMask!");
+    if (!window.ethereum) { alert("Please install MetaMask or another Base-compatible wallet."); return; }
+    try {
+        if (!window.ethers) throw new Error("Ethers library failed to load.");
+        await ensureNetwork();
+        provider = new ethers.providers.Web3Provider(window.ethereum, "any");
+        await provider.send("eth_requestAccounts", []);
+        signer = provider.getSigner();
+        const address = await signer.getAddress();
+        const connectBtn = getElement("connectBtn");
+        const walletAddress = getElement("walletAddress");
+        if (connectBtn) connectBtn.style.display = "none";
+        if (walletAddress) walletAddress.style.display = "inline-block";
+        setText("walletAddress", `Connected: ${address.substring(0, 6)}...${address.substring(38)}`);
+        if (!isPresaleConfigured()) throw new Error("The verified presale configuration is not live.");
+        presaleContract = new ethers.Contract(PRESALE_CONTRACT_ADDRESS, PRESALE_ABI, provider);
+        setText("contractAddr", PRESALE_CONTRACT_ADDRESS);
+        await loadPresaleData();
+    } catch (error) {
+        console.error("Connection failed", error);
+        setPurchaseControlsEnabled(false, "Connect Wallet");
+        alert("Wallet connection failed: " + (error.reason || error.message));
     }
 }
 
 async function loadPresaleData() {
-    if(!presaleContract) return;
+    if (!presaleContract) return;
     try {
-        const rate = await presaleContract.rate();
+        const [rate, raised, reserved, tokenAddress, softCap, hardCap, minimum, maximum, start, end, finalized, cancelled] = await Promise.all([
+            presaleContract.rate(), presaleContract.weiRaised(), presaleContract.tokensReserved(), presaleContract.token(),
+            presaleContract.softCap(), presaleContract.hardCap(), presaleContract.minContribution(), presaleContract.maxContribution(),
+            presaleContract.startTime(), presaleContract.endTime(), presaleContract.finalized(), presaleContract.cancelled()
+        ]);
+        if (tokenAddress.toLowerCase() !== AETH_TOKEN_ADDRESS.toLowerCase()) throw new Error("Presale token linkage does not match verified AETH.");
+        const tokenContract = new ethers.Contract(AETH_TOKEN_ADDRESS, ERC20_ABI, provider);
+        const [tokenBalance, decimals] = await Promise.all([tokenContract.balanceOf(PRESALE_CONTRACT_ADDRESS), tokenContract.decimals()]);
+        if (tokenBalance.lt(reserved)) throw new Error("Presale inventory is below reserved-token liability.");
+        let userContribution = ethers.constants.Zero;
+        if (signer) userContribution = await presaleContract.contributions(await signer.getAddress());
+
         currentRate = rate.toNumber();
-        document.getElementById('rateDisplay').innerText = `1 MATIC = ${currentRate} AETH`;
+        totalRaisedETH = parseFloat(ethers.utils.formatEther(raised));
+        hardCapETH = parseFloat(ethers.utils.formatEther(hardCap));
+        minContributionETH = parseFloat(ethers.utils.formatEther(minimum));
+        maxContributionETH = parseFloat(ethers.utils.formatEther(maximum));
+        userContributionETH = parseFloat(ethers.utils.formatEther(userContribution));
 
-        const raised = await presaleContract.weiRaised();
-        const raisedMatic = ethers.utils.formatEther(raised);
-        totalRaisedMatic = parseFloat(raisedMatic);
-        document.getElementById('raisedDisplay').innerText = `${formatNumber(totalRaisedMatic, 2)} MATIC`;
+        const inventory = parseFloat(ethers.utils.formatUnits(tokenBalance, decimals));
+        const reservedTokens = parseFloat(ethers.utils.formatUnits(reserved, decimals));
+        availablePurchaseTokens = Math.min(
+            Math.max(inventory - reservedTokens, 0),
+            Math.max((hardCapETH - totalRaisedETH) * currentRate, 0),
+            Math.max(MAX_PRESALE_TOKENS - reservedTokens, 0)
+        );
 
-        const maxMaticByUsd = getMaxMaticByUsd();
-        const maxMaticByTokens = getMaxMaticByTokens(currentRate);
-        const effectiveMaticCap = getEffectiveMaticCap(currentRate);
+        setText("rateDisplay", `1 ETH = ${currentRate.toLocaleString()} AETH`);
+        setText("raisedDisplay", `${formatNumber(totalRaisedETH, 6)} ETH`);
+        setText("maxTokensDisplay", `${formatNumber(availablePurchaseTokens, 2)} AETH available`);
+        setText("maxRaiseDisplay", `${formatNumber(hardCapETH, 6)} ETH`);
+        const progressBar = getElement("progressBar");
+        if (progressBar) progressBar.style.width = `${Math.min((totalRaisedETH / hardCapETH) * 100, 100).toFixed(2)}%`;
 
-        const tokenCapDisplay = `${MAX_PRESALE_TOKENS.toLocaleString()} AETH`;
-        const usdCapDisplay = `$${MAX_TOTAL_USD.toLocaleString()}`;
-        document.getElementById('maxTokensDisplay').innerText = tokenCapDisplay;
-        document.getElementById('maxRaiseDisplay').innerText = usdCapDisplay;
-
-        const progress = Math.min((totalRaisedMatic / effectiveMaticCap) * 100, 100);
-        document.getElementById('progressBar').style.width = `${progress.toFixed(2)}%`;
-
-        const capNote = `Caps: ${formatNumber(maxMaticByUsd, 2)} MATIC ($${MAX_TOTAL_USD.toLocaleString()}) or ${formatNumber(maxMaticByTokens, 2)} MATIC (${MAX_PRESALE_TOKENS.toLocaleString()} AETH), whichever comes first.`;
-        document.getElementById('capStatus').innerText = capNote;
-        
-    } catch(err) {
-        console.error("Error loading data", err);
+        const now = Math.floor(Date.now() / 1000);
+        const starts = start.toNumber();
+        const ends = end.toNumber();
+        presaleIsLive = now >= starts && now <= ends && !finalized && !cancelled;
+        if (presaleIsLive) {
+            const walletRemaining = Math.max(maxContributionETH - userContributionETH, 0);
+            setText("capStatus", `Soft Cap: ${formatNumber(parseFloat(ethers.utils.formatEther(softCap)), 6)} ETH | Hard Cap: ${formatNumber(hardCapETH, 6)} ETH | Wallet Remaining: ${formatNumber(walletRemaining, 6)} ETH`);
+            setPurchaseControlsEnabled(walletRemaining >= minContributionETH && availablePurchaseTokens > 0, "Enter Amount");
+        } else if (finalized) {
+            setHtml("capStatus", '<span style="color:#22c55e;">Presale finalized.</span>');
+            setPurchaseControlsEnabled(false, "Finalized");
+        } else if (cancelled || now > ends) {
+            setHtml("capStatus", '<span style="color:#ef4444;">Presale ended. Refunds may be available.</span>');
+            const section = getElement("refundSection"); if (section) section.style.display = "block";
+            setPurchaseControlsEnabled(false, "Presale Ended");
+        } else {
+            setHtml("capStatus", '<span style="color:#f59e0b;">Presale has not started.</span>');
+            setPurchaseControlsEnabled(false, "Not Started");
+        }
+    } catch (error) {
+        console.error("Error loading presale", error);
+        setPresaleUnavailable(error.message || "Unable to verify the presale contract. Purchases are disabled.");
     }
 }
 
 function calculateTokens() {
-    const maticInput = document.getElementById('maticAmount').value;
-    const warning = document.getElementById('capWarning');
-    const buyBtn = document.getElementById('buyBtn');
-
-    warning.style.display = 'none';
-    warning.innerText = '';
-
-    if(maticInput > 0) {
-        const effectiveMaticCap = getEffectiveMaticCap(currentRate);
-        const remainingMatic = Math.max(effectiveMaticCap - totalRaisedMatic, 0);
-        const maticAmount = parseFloat(maticInput);
-        const tokens = maticInput * currentRate;
-        document.getElementById('tokenAmount').value = tokens + " AETH";
-
-        if (maticAmount > remainingMatic) {
-            warning.innerText = `Cap reached or exceeded. Remaining capacity: ${formatNumber(remainingMatic, 2)} MATIC.`;
-            warning.style.display = 'block';
-            buyBtn.disabled = true;
-            buyBtn.innerText = "Cap Reached";
-            return;
-        }
-
-        if (tokens > MAX_PRESALE_TOKENS) {
-            warning.innerText = `Token cap exceeded. Max presale tokens: ${MAX_PRESALE_TOKENS.toLocaleString()} AETH.`;
-            warning.style.display = 'block';
-            buyBtn.disabled = true;
-            buyBtn.innerText = "Cap Reached";
-            return;
-        }
-
-        if(signer) buyBtn.disabled = false;
-        buyBtn.innerText = "Buy Tokens";
-    } else {
-        document.getElementById('tokenAmount').value = "";
-        buyBtn.disabled = true;
-    }
+    const input = getElement("maticAmount");
+    const output = getElement("tokenAmount");
+    const warning = getElement("capWarning");
+    const buyBtn = getElement("buyBtn");
+    if (!input || !output || !warning || !buyBtn) return;
+    const amount = Number(input.value);
+    warning.style.display = "none";
+    if (!presaleContract || !presaleIsLive) { setPurchaseControlsEnabled(false, "Unavailable"); return; }
+    if (!Number.isFinite(amount) || amount <= 0) { output.value = ""; buyBtn.disabled = true; return; }
+    output.value = `${(amount * currentRate).toLocaleString()} AETH`;
+    const error = validatePurchaseAmount(amount);
+    if (error) { warning.innerText = error; warning.style.display = "block"; buyBtn.disabled = true; buyBtn.innerText = "Invalid Amount"; return; }
+    buyBtn.disabled = !signer;
+    buyBtn.innerText = "Buy Tokens";
 }
 
 async function buyTokens() {
-    if(!presaleContract || !signer) return;
-    
-    const maticAmount = document.getElementById('maticAmount').value;
-    if(!maticAmount) return;
-
-    const effectiveMaticCap = getEffectiveMaticCap(currentRate);
-    const remainingMatic = Math.max(effectiveMaticCap - totalRaisedMatic, 0);
-    const maticValue = parseFloat(maticAmount);
-    if (maticValue > remainingMatic) {
-        alert(`Cap reached. Remaining capacity: ${formatNumber(remainingMatic, 2)} MATIC.`);
-        return;
-    }
-
+    if (!presaleContract || !signer || !presaleIsLive) { alert("Presale is not available."); return; }
+    const input = getElement("maticAmount");
+    const buyBtn = getElement("buyBtn");
+    const amount = input?.value || "";
+    const error = validatePurchaseAmount(Number(amount));
+    if (error) { alert(error); return; }
     try {
-        document.getElementById('buyBtn').innerText = "Processing...";
-        document.getElementById('buyBtn').disabled = true;
-
-        const presaleWithSigner = presaleContract.connect(signer);
-        const tx = await presaleWithSigner.buyTokens({
-            value: ethers.utils.parseEther(maticAmount)
-        });
-        
-        alert("Transaction Sent! Waiting for confirmation...");
-        
+        buyBtn.disabled = true; buyBtn.innerText = "Simulating...";
+        const writable = presaleContract.connect(signer);
+        const value = ethers.utils.parseEther(amount);
+        await writable.callStatic.buyTokens({ value });
+        const estimate = await writable.estimateGas.buyTokens({ value });
+        buyBtn.innerText = "Confirm in Wallet";
+        const tx = await writable.buyTokens({ value, gasLimit: estimate.mul(120).div(100) });
+        alert("Purchase submitted. Waiting for Base confirmation...");
         await tx.wait();
-        
-        alert("Success! tokens purchased.");
-        document.getElementById('buyBtn').innerText = "Buy Tokens";
-        document.getElementById('maticAmount').value = "";
-        loadPresaleData();
-
+        alert("Success! Your AETH allocation is reserved.");
+        input.value = "";
+        await loadPresaleData();
     } catch (error) {
         console.error(error);
-        alert("Transaction failed: " + (error.reason || error.message));
-        document.getElementById('buyBtn').innerText = "Buy Tokens";
-        document.getElementById('buyBtn').disabled = false;
+        alert("Transaction failed: " + (error.reason || error.data?.message || error.message));
+    } finally {
+        buyBtn.innerText = "Buy Tokens";
+        calculateTokens();
     }
 }
 
-// Auto connect if already permitted
-if(window.ethereum && window.ethereum.selectedAddress) {
-    connectWallet();
+async function claimRefund() {
+    if (!presaleContract || !signer) return;
+    try { const tx = await presaleContract.connect(signer).claimRefund(); await tx.wait(); alert("Refund claimed."); await loadPresaleData(); }
+    catch (error) { alert("Refund failed: " + (error.reason || error.message)); }
 }
+
+async function withdrawToTreasury() {
+    if (!presaleContract || !signer) return;
+    try { const tx = await presaleContract.connect(signer).withdrawFunds(); await tx.wait(); alert("Funds withdrawn to treasury."); await loadPresaleData(); }
+    catch (error) { alert("Withdrawal failed: " + (error.reason || error.message)); }
+}
+
+if (!isPresaleConfigured()) setPresaleUnavailable("The verified Base presale configuration is unavailable.");
+else { setText("contractAddr", PRESALE_CONTRACT_ADDRESS); setPurchaseControlsEnabled(false, "Connect Wallet"); }
+if (window.ethereum && window.ethereum.selectedAddress) connectWallet();


### PR DESCRIPTION
## What changed

- Replaces the obsolete Polygon/MATIC presale page with the verified Base/ETH purchase page.
- Publishes the live Base presale contract configuration.
- Adds guarded wallet switching, contract/token linkage checks, inventory checks, contribution-limit checks, transaction simulation, and gas estimation before purchase.
- Publishes the `aetrs.com` CNAME as clean UTF-8 text.

## Live terms

- Contract: `0xe0A3B6368312dFd3E7E76202e673f895f8235A3d`
- Token: `0xecf7E17faE148C01E1b5008A31Dfd2d1B6608E4e`
- Network: Base (`8453`)
- Minimum: `0.0003 ETH`
- Maximum per wallet: `33.333333 ETH`
- Rate: `1,000,000 AETH / ETH`

## Safety

The page disables purchases unless the configuration is marked live, the wallet is on Base, contract reads succeed, the contract token matches verified AETH, inventory covers reservations, the sale window is open, and the requested amount passes wallet/hard-cap/inventory constraints. It runs `callStatic.buyTokens` before broadcasting.

## Deployment impact

Merging into `gh-pages` publishes these assets through the repository’s public Pages branch and restores the `aetrs.com` custom-domain marker.