### PR TITLE
fix: make aetrs.com Base-presale advertising ready

### DIFF
--- a/index-dom-overrides.js
+++ b/index-dom-overrides.js
@@ -1,204 +1,108 @@
 import { renderWalletStatus, renderTransactions, createIndexWalletChooserModal, renderUserStakes } from './index-safe-renderers.js';
 
-function patchIndexRenderers() {
-  const g = window;
+const TOKEN = '0xecf7E17faE148C01E1b5008A31Dfd2d1B6608E4e';
+const PRESALE = '0xe0A3B6368312dFd3E7E76202e673f895f8235A3d';
+const BASESCAN_TOKEN = `https://basescan.org/token/${TOKEN}`;
 
-  const originalCheckWalletStatus = g.checkWalletStatus;
-  g.checkWalletStatus = async function () {
-    const statusDiv = document.getElementById('walletStatus');
-    if (!statusDiv) {
-      console.warn('Wallet status element not found - page may not be fully loaded');
-      return false;
+window.POLYGON_RPC_URLS = ['https://mainnet.base.org', 'https://base.drpc.org', 'https://rpc.ankr.com/base'];
+
+function replaceText(root, replacements) {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const nodes = [];
+  while (walker.nextNode()) nodes.push(walker.currentNode);
+  nodes.forEach((node) => {
+    let value = node.nodeValue;
+    replacements.forEach(([from, to]) => { value = value.split(from).join(to); });
+    node.nodeValue = value;
+  });
+}
+
+function reconcilePublicHomepage() {
+  replaceText(document.body, [
+    ['0xAb5ae0D8f569d7c2B27574319b864a5bA6F9671e', TOKEN],
+    ['0xAb5a...9671e', '0xecf7...8E4e'],
+    ['Polygon Mainnet', 'Base Mainnet'],
+    ['PolygonScan', 'BaseScan'],
+    ['MATIC', 'ETH'],
+    ['QuickSwap', 'verified presale'],
+    ['1 ETH = 1000 AETH', '1 ETH = 1,000,000 AETH'],
+    ['Minimum: 0.001 ETH', 'Minimum: 0.0003 ETH'],
+    ['100+ Holders', 'Verified on Base'],
+    ['Polygon DeFi Command', 'Base DeFi Command']
+  ]);
+
+  document.querySelectorAll('a').forEach((link) => {
+    const href = link.getAttribute('href') || '';
+    if (/quickswap|polygonscan|dexscreener\.com\/polygon/i.test(href)) {
+      link.href = link.textContent.includes('BaseScan') ? BASESCAN_TOKEN : 'presale.html';
+      if (link.href.endsWith('presale.html')) link.removeAttribute('target');
     }
+  });
 
-    const wallet = typeof g.resolveInjectedProvider === 'function' ? g.resolveInjectedProvider() : null;
-    const walletName = typeof g.getWalletName === 'function' ? g.getWalletName(wallet) : '';
+  const copy = document.getElementById('copyContractBtn');
+  if (copy) copy.dataset.contract = TOKEN;
+  document.querySelectorAll('.contract-address-info').forEach((node) => { node.textContent = TOKEN; });
 
-    if (wallet) {
-      renderWalletStatus(statusDiv, 'detected', walletName);
-      return true;
-    }
+  const heroBadges = [...document.querySelectorAll('.hero-badge, .badge, .status-badge')];
+  heroBadges.forEach((badge) => {
+    if (/holders/i.test(badge.textContent)) badge.textContent = '● Verified on Base';
+  });
 
-    if (window.ethereum) {
-      renderWalletStatus(statusDiv, 'other');
-      return false;
-    }
+  const faqAnswers = document.querySelectorAll('.faq-answer');
+  if (faqAnswers[0]) faqAnswers[0].innerHTML = `<p>To buy AETH:</p><ol><li>Open the verified <a class="primary-link" href="presale.html">Base presale</a>.</li><li>Connect MetaMask or Coinbase Wallet.</li><li>Switch to Base Mainnet and enter at least 0.0003 ETH.</li><li>Review the quote and confirm the transaction in your wallet.</li></ol>`;
+  if (faqAnswers[1]) faqAnswers[1].innerHTML = '<p>Public staking is not being advertised as active yet. The calculator is for planning only until a Base staking contract and final reward schedule are published.</p>';
+  if (faqAnswers[2]) faqAnswers[2].innerHTML = '<p>The presale purchase uses ETH on Base Mainnet plus the wallet’s network gas fee. The page shows the token quote before confirmation. No exchange-liquidity or trading claim is made during the presale phase.</p>';
+  if (faqAnswers[3]) faqAnswers[3].innerHTML = `<p>The live presale and AETH token source code are verified on BaseScan. Contract verification is not the same as an independent security audit; buyers should review the verified code and transaction details.</p><p><a class="primary-link" target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/${PRESALE}#code">View verified presale</a></p>`;
+  if (faqAnswers[4]) faqAnswers[4].innerHTML = '<p>This question applies only after a Base staking program is publicly activated. No active staking deposit is promoted on this page today.</p>';
+  if (faqAnswers[5]) faqAnswers[5].innerHTML = `<p>Click “Add to MetaMask,” or add the token manually:</p><ul><li><strong>Network:</strong> Base Mainnet</li><li><strong>Contract:</strong> ${TOKEN}</li><li><strong>Symbol:</strong> AETH</li><li><strong>Decimals:</strong> 18</li></ul>`;
 
-    renderWalletStatus(statusDiv, 'missing');
-    return false;
+  window.calcPresaleTokens = function () {
+    const input = document.getElementById('presaleMaticInput');
+    const output = document.getElementById('presaleTokenOutput');
+    if (input && output) output.value = `${((Number(input.value) || 0) * 1000000).toLocaleString()} AETH`;
   };
 
-  const originalDisplayTransactions = g.displayTransactions;
-  g.displayTransactions = function (transactions) {
+  const style = document.createElement('style');
+  style.textContent = `
+    .hero-grid,.feature-grid,.dashboard-grid{align-items:stretch}
+    .feature-card,.card,.command-deck{overflow:hidden;min-width:0}
+    .contract-address,.contract-address-info{overflow-wrap:anywhere}
+    input,select,button,.btn{min-height:44px}
+    @media(max-width:900px){.hero-grid,.dashboard-grid{grid-template-columns:1fr!important}.hero-title{font-size:clamp(3rem,12vw,5.4rem)!important;line-height:.95}.contract-display{max-width:100%;overflow:hidden}.contract-display span{overflow-wrap:anywhere}}
+  `;
+  document.head.appendChild(style);
+}
+
+function patchSafeRenderers() {
+  window.checkWalletStatus = async function () {
+    const status = document.getElementById('walletStatus');
+    if (!status) return false;
+    const wallet = window.resolveInjectedProvider?.() || window.ethereum;
+    renderWalletStatus(status, wallet ? 'detected' : 'missing', wallet?.isCoinbaseWallet ? 'Coinbase Wallet' : wallet?.isMetaMask ? 'MetaMask' : 'Browser Wallet');
+    return Boolean(wallet);
+  };
+  window.displayTransactions = function (transactions) {
     const list = document.getElementById('txList');
-    const txEmpty = document.getElementById('txEmpty');
-    if (!list || !txEmpty) {
-      if (typeof originalDisplayTransactions === 'function') {
-        return originalDisplayTransactions.call(this, transactions);
-      }
-      return;
-    }
-
-    if (!transactions || transactions.length === 0) {
-      txEmpty.classList.remove('hidden');
-      list.classList.add('hidden');
-      list.replaceChildren();
-      return;
-    }
-
-    txEmpty.classList.add('hidden');
-    list.classList.remove('hidden');
-    renderTransactions(list, transactions);
+    if (list) renderTransactions(list, Array.isArray(transactions) ? transactions : []);
   };
-
-  const originalEnsureWalletChooser = g.ensureWalletChooser;
-  g.ensureWalletChooser = function () {
+  window.ensureWalletChooser = function () {
     let modal = document.getElementById('walletChooserModal');
-    if (modal) {
-      return modal;
-    }
-
-    modal = createIndexWalletChooserModal();
-    document.body.appendChild(modal);
-
-    const closeChooser = () => {
-      modal.style.display = 'none';
-      modal.classList.remove('show');
-    };
-
-    const closeButton = modal.querySelector('#walletChooserClose');
-    if (closeButton) {
-      closeButton.addEventListener('click', closeChooser);
-      closeButton.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          closeChooser();
-        }
-      });
-    }
-
-    modal.addEventListener('mousedown', (event) => {
-      const content = modal.querySelector('.modal-content');
-      if (content && !content.contains(event.target)) {
-        closeChooser();
-      }
-    });
-
-    const metaMaskBtn = modal.querySelector('#walletChooserMetaMask');
-    const coinbaseBtn = modal.querySelector('#walletChooserCoinbase');
-    const browserBtn = modal.querySelector('#walletChooserBrowser');
-
-    metaMaskBtn?.addEventListener('click', async () => {
-      closeChooser();
-      await g.connectWallet?.({ walletType: 'metamask' });
-    });
-
-    coinbaseBtn?.addEventListener('click', async () => {
-      closeChooser();
-      await g.connectWallet?.({ walletType: 'coinbase' });
-    });
-
-    browserBtn?.addEventListener('click', async () => {
-      closeChooser();
-      await g.connectWallet?.();
-    });
-
+    if (!modal) { modal = createIndexWalletChooserModal(); document.body.appendChild(modal); }
     return modal;
   };
-
-  const originalDisplayUserStakes = g.displayUserStakes;
-  g.displayUserStakes = function (stakes) {
-    let container = document.getElementById('userStakesContainer');
-    if (!container) {
-      const walletCard = document.querySelector('.card.mb-2');
-      if (walletCard) {
-        container = document.createElement('div');
-        container.id = 'userStakesContainer';
-        container.className = 'card mb-2';
-
-        const header = document.createElement('div');
-        header.className = 'card-header';
-        const title = document.createElement('h2');
-        title.className = 'card-title';
-        title.textContent = 'Your Active Stakes';
-        const button = document.createElement('button');
-        button.className = 'btn btn-outline btn-sm';
-        button.type = 'button';
-        const icon = document.createElement('i');
-        icon.className = 'fas fa-sync-alt';
-        button.append(icon, document.createTextNode(' Refresh'));
-        button.addEventListener('click', () => g.loadUserStakes?.());
-        header.append(title, button);
-
-        const list = document.createElement('div');
-        list.className = 'user-stakes';
-        list.id = 'userStakesList';
-
-        container.append(header, list);
-        walletCard.parentNode.insertBefore(container, walletCard.nextSibling);
-      }
-    }
-
+  window.displayUserStakes = function (stakes) {
     const list = document.getElementById('userStakesList');
-    if (!list) {
-      if (typeof originalDisplayUserStakes === 'function') {
-        return originalDisplayUserStakes.call(this, stakes);
-      }
-      return;
-    }
-
-    renderUserStakes(list, Array.isArray(stakes) ? stakes : []);
-
-    list.querySelectorAll('[data-claim-stake-id]').forEach((button) => {
-      button.addEventListener('click', () => g.claimStakeRewards?.(Number(button.dataset.claimStakeId)));
-    });
-
-    list.querySelectorAll('[data-stake-action]').forEach((button) => {
-      const stakeId = Number(button.dataset.stakeId);
-      button.addEventListener('click', () => {
-        if (button.dataset.stakeAction === 'unstake') {
-          g.unstakeTokens?.(stakeId);
-        } else {
-          g.emergencyUnstake?.(stakeId);
-        }
-      });
-    });
+    if (list) renderUserStakes(list, Array.isArray(stakes) ? stakes : []);
   };
-
-  const originalShowQRCode = g.showQRCode;
-  g.showQRCode = function () {
+  window.showQRCode = function () {
     const modal = document.getElementById('qrModal');
-    const qrcodeContainer = document.getElementById('qrcode');
-    if (!modal || !qrcodeContainer) {
-      if (typeof originalShowQRCode === 'function') {
-        return originalShowQRCode.call(this);
-      }
-      return;
-    }
-
-    qrcodeContainer.replaceChildren();
-    new QRCode(qrcodeContainer, {
-      text: '0xAb5ae0D8f569d7c2B27574319b864a5bA6F9671e',
-      width: 256,
-      height: 256,
-      colorDark: '#000000',
-      colorLight: '#ffffff',
-      correctLevel: QRCode.CorrectLevel.H,
-    });
-
+    const container = document.getElementById('qrcode');
+    if (!modal || !container || typeof QRCode === 'undefined') return;
+    container.replaceChildren();
+    new QRCode(container, { text: TOKEN, width: 256, height: 256, correctLevel: QRCode.CorrectLevel.H });
     modal.style.display = 'block';
-
-    if (typeof g.gtag !== 'undefined') {
-      g.gtag('event', 'show_qr_code', {
-        event_category: 'engagement',
-        event_label: 'contract_qr',
-      });
-    }
   };
 }
 
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', patchIndexRenderers);
-} else {
-  patchIndexRenderers();
-}
+function init() { patchSafeRenderers(); reconcilePublicHomepage(); }
+if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();

--- a/monitor.js
+++ b/monitor.js
@@ -1,468 +1,57 @@
-// monitor.js - Platform monitoring, live trading banner, and market analytics
+// Public launch status banner for the verified Base presale.
 class AetheronMonitor {
   constructor() {
     this.contracts = {
-      AETH: '0xAb5ae0D8f569d7c2B27574319b864a5bA6F9671e',
-      STAKING: '0x896D9d37A67B0bBf81dde0005975DA7850FFa638',
-      PAIR: '0xd57c5E33ebDC1b565F99d06809debbf86142705D'
+      AETH: '0xecf7E17faE148C01E1b5008A31Dfd2d1B6608E4e',
+      PRESALE: '0xe0A3B6368312dFd3E7E76202e673f895f8235A3d'
     };
     this.links = {
-      trade: 'https://quickswap.exchange/#/swap?outputCurrency=0xAb5ae0D8f569d7c2B27574319b864a5bA6F9671e',
-      pair: 'https://dexscreener.com/polygon/0xd57c5E33ebDC1b565F99d06809debbf86142705D',
-      analytics: 'analytics-dashboard.html',
-      token: 'https://polygonscan.com/token/0xAb5ae0D8f569d7c2B27574319b864a5bA6F9671e'
+      buy: 'presale.html',
+      presale: 'https://basescan.org/address/0xe0A3B6368312dFd3E7E76202e673f895f8235A3d#code',
+      token: 'https://basescan.org/token/0xecf7E17faE148C01E1b5008A31Dfd2d1B6608E4e'
     };
-    this.metrics = {
-      pageViews: 0,
-      walletConnections: 0,
-      transactions: 0,
-      stakingActivity: 0,
-      errors: 0,
-      holderEstimate: 0,
-      liquidityUsd: 0,
-      volume24h: 0,
-      priceUsd: 0
-    };
-    this.marketSnapshot = null;
-    this.marketPollIntervalMs = 60000;
-    this.minimumLiveLiquidityUsd = 100;
     this.init();
   }
 
   init() {
-    this.injectBannerStyles();
-    this.trackPageViews();
-    this.monitorWalletConnections();
-    this.monitorContractActivity();
-    this.setupErrorTracking();
-    this.setupLiveTradingBanner();
-    this.startMarketWatcher();
-    this.sendMetrics();
+    this.injectStyles();
+    this.renderPresaleBanner();
   }
 
-  injectBannerStyles() {
-    if (document.getElementById('aetheron-live-banner-styles')) {
-      return;
-    }
-
+  injectStyles() {
+    if (document.getElementById('aetheron-live-banner-styles')) return;
     const style = document.createElement('style');
     style.id = 'aetheron-live-banner-styles';
     style.textContent = `
-      .aetheron-live-banner {
-        display: grid;
-        grid-template-columns: 1.2fr 2fr auto;
-        gap: 16px;
-        align-items: center;
-        margin: 16px auto 20px;
-        padding: 16px 18px;
-        border-radius: 18px;
-        border: 1px solid rgba(255,255,255,0.12);
-        background: linear-gradient(135deg, rgba(17,24,39,0.92), rgba(76,29,149,0.72));
-        box-shadow: 0 20px 45px rgba(0,0,0,0.28);
-        color: #fff;
-      }
-      .aetheron-live-banner.is-live {
-        border-color: rgba(34,197,94,0.45);
-        box-shadow: 0 20px 45px rgba(34,197,94,0.16);
-      }
-      .aetheron-live-banner__status {
-        display: flex;
-        flex-direction: column;
-        gap: 6px;
-      }
-      .aetheron-live-banner__eyebrow {
-        font-size: 0.78rem;
-        text-transform: uppercase;
-        letter-spacing: 0.12em;
-        color: rgba(255,255,255,0.7);
-      }
-      .aetheron-live-banner__headline {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-        font-size: 1.15rem;
-        font-weight: 700;
-      }
-      .aetheron-live-banner__dot {
-        width: 11px;
-        height: 11px;
-        border-radius: 999px;
-        background: #f59e0b;
-        box-shadow: 0 0 0 0 rgba(245,158,11,0.6);
-        animation: aetheronPulse 1.8s infinite;
-      }
-      .aetheron-live-banner.is-live .aetheron-live-banner__dot {
-        background: #22c55e;
-        box-shadow: 0 0 0 0 rgba(34,197,94,0.5);
-      }
-      .aetheron-live-banner__meta {
-        display: grid;
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-        gap: 10px;
-      }
-      .aetheron-live-banner__metric {
-        background: rgba(255,255,255,0.08);
-        border-radius: 14px;
-        padding: 10px 12px;
-      }
-      .aetheron-live-banner__metric-label {
-        font-size: 0.72rem;
-        color: rgba(255,255,255,0.68);
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        margin-bottom: 4px;
-      }
-      .aetheron-live-banner__metric-value {
-        font-size: 0.98rem;
-        font-weight: 700;
-      }
-      .aetheron-live-banner__actions {
-        display: flex;
-        gap: 10px;
-        flex-wrap: wrap;
-        justify-content: flex-end;
-      }
-      .aetheron-live-banner__button {
-        display: inline-flex;
-        align-items: center;
-        gap: 8px;
-        padding: 10px 14px;
-        border-radius: 999px;
-        text-decoration: none;
-        color: #fff;
-        border: 1px solid rgba(255,255,255,0.15);
-        background: rgba(255,255,255,0.08);
-        font-weight: 600;
-      }
-      .aetheron-live-banner__button--primary {
-        background: linear-gradient(135deg, #22c55e, #16a34a);
-        border-color: rgba(34,197,94,0.35);
-      }
-      @keyframes aetheronPulse {
-        0% { box-shadow: 0 0 0 0 rgba(34,197,94,0.45); }
-        70% { box-shadow: 0 0 0 12px rgba(34,197,94,0); }
-        100% { box-shadow: 0 0 0 0 rgba(34,197,94,0); }
-      }
-      @media (max-width: 960px) {
-        .aetheron-live-banner {
-          grid-template-columns: 1fr;
-        }
-        .aetheron-live-banner__meta {
-          grid-template-columns: repeat(2, minmax(0, 1fr));
-        }
-        .aetheron-live-banner__actions {
-          justify-content: flex-start;
-        }
-      }
-      @media (max-width: 640px) {
-        .aetheron-live-banner__meta {
-          grid-template-columns: 1fr 1fr;
-        }
-      }
+      .aetheron-live-banner{display:grid;grid-template-columns:1.15fr 2fr auto;gap:16px;align-items:center;margin:20px auto;padding:18px;border-radius:20px;border:1px solid rgba(52,211,153,.4);background:linear-gradient(135deg,rgba(7,24,39,.96),rgba(46,20,101,.84));box-shadow:0 22px 50px rgba(0,0,0,.28);color:#fff}
+      .aetheron-live-banner__status{display:flex;flex-direction:column;gap:7px}.aetheron-live-banner__eyebrow{font-size:.76rem;text-transform:uppercase;letter-spacing:.12em;color:rgba(255,255,255,.7)}
+      .aetheron-live-banner__headline{display:flex;align-items:center;gap:10px;font-size:1.14rem;font-weight:800}.aetheron-live-banner__dot{width:11px;height:11px;border-radius:50%;background:#34d399;box-shadow:0 0 18px rgba(52,211,153,.8)}
+      .aetheron-live-banner__meta{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}.aetheron-live-banner__metric{background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.08);border-radius:14px;padding:11px 12px}
+      .aetheron-live-banner__metric-label{font-size:.7rem;color:rgba(255,255,255,.65);text-transform:uppercase;letter-spacing:.08em;margin-bottom:4px}.aetheron-live-banner__metric-value{font-size:.95rem;font-weight:800}
+      .aetheron-live-banner__actions{display:flex;gap:9px;flex-wrap:wrap;justify-content:flex-end}.aetheron-live-banner__button{display:inline-flex;align-items:center;padding:10px 14px;border-radius:999px;text-decoration:none;color:#fff;border:1px solid rgba(255,255,255,.16);background:rgba(255,255,255,.08);font-weight:700}.aetheron-live-banner__button--primary{background:linear-gradient(135deg,#22c55e,#16a34a)}
+      @media(max-width:960px){.aetheron-live-banner{grid-template-columns:1fr}.aetheron-live-banner__meta{grid-template-columns:repeat(2,1fr)}.aetheron-live-banner__actions{justify-content:flex-start}}
     `;
     document.head.appendChild(style);
   }
 
-  setupLiveTradingBanner() {
-    const mainContent = document.querySelector('#main-content .container') || document.querySelector('main .container') || document.body;
-    if (!mainContent || document.getElementById('aetheronLiveTradingBanner')) {
-      return;
-    }
-
+  renderPresaleBanner() {
+    const host = document.querySelector('#main-content .container') || document.querySelector('main .container') || document.body;
+    if (!host || document.getElementById('aetheronLiveTradingBanner')) return;
     const banner = document.createElement('section');
     banner.id = 'aetheronLiveTradingBanner';
     banner.className = 'aetheron-live-banner';
+    banner.setAttribute('aria-label', 'Verified Base presale status');
     banner.innerHTML = `
-      <div class="aetheron-live-banner__status">
-        <div class="aetheron-live-banner__eyebrow">Market Status</div>
-        <div class="aetheron-live-banner__headline">
-          <span class="aetheron-live-banner__dot" aria-hidden="true"></span>
-          <span id="aetheronLiveHeadline">Preparing live trading...</span>
-        </div>
-        <div id="aetheronLiveSubhead" class="aetheron-live-banner__eyebrow">Waiting for live liquidity signal from DexScreener.</div>
-      </div>
+      <div class="aetheron-live-banner__status"><div class="aetheron-live-banner__eyebrow">Sale status</div><div class="aetheron-live-banner__headline"><span class="aetheron-live-banner__dot"></span><span>BASE PRESALE LIVE</span></div><div class="aetheron-live-banner__eyebrow">Purchase through the verified contract on Base Mainnet.</div></div>
       <div class="aetheron-live-banner__meta">
-        <div class="aetheron-live-banner__metric">
-          <div class="aetheron-live-banner__metric-label">Price</div>
-          <div class="aetheron-live-banner__metric-value" id="aetheronBannerPrice">--</div>
-        </div>
-        <div class="aetheron-live-banner__metric">
-          <div class="aetheron-live-banner__metric-label">Liquidity</div>
-          <div class="aetheron-live-banner__metric-value" id="aetheronBannerLiquidity">--</div>
-        </div>
-        <div class="aetheron-live-banner__metric">
-          <div class="aetheron-live-banner__metric-label">24h Volume</div>
-          <div class="aetheron-live-banner__metric-value" id="aetheronBannerVolume">--</div>
-        </div>
-        <div class="aetheron-live-banner__metric">
-          <div class="aetheron-live-banner__metric-label">Holders</div>
-          <div class="aetheron-live-banner__metric-value" id="aetheronBannerHolders">--</div>
-        </div>
+        <div class="aetheron-live-banner__metric"><div class="aetheron-live-banner__metric-label">Minimum</div><div class="aetheron-live-banner__metric-value">0.0003 ETH</div></div>
+        <div class="aetheron-live-banner__metric"><div class="aetheron-live-banner__metric-label">Rate</div><div class="aetheron-live-banner__metric-value">1M AETH / ETH</div></div>
+        <div class="aetheron-live-banner__metric"><div class="aetheron-live-banner__metric-label">Network</div><div class="aetheron-live-banner__metric-value">Base Mainnet</div></div>
+        <div class="aetheron-live-banner__metric"><div class="aetheron-live-banner__metric-label">Contract</div><div class="aetheron-live-banner__metric-value">Verified</div></div>
       </div>
-      <div class="aetheron-live-banner__actions">
-        <a class="aetheron-live-banner__button aetheron-live-banner__button--primary" href="${this.links.trade}" target="_blank" rel="noopener noreferrer">Trade AETH</a>
-        <a class="aetheron-live-banner__button" href="${this.links.pair}" target="_blank" rel="noopener noreferrer">DexScreener</a>
-        <a class="aetheron-live-banner__button" href="${this.links.analytics}">Analytics</a>
-      </div>
-    `;
-
-    const insertionTarget = mainContent.firstElementChild;
-    if (insertionTarget) {
-      mainContent.insertBefore(banner, insertionTarget.nextSibling || insertionTarget);
-    } else {
-      mainContent.prepend(banner);
-    }
-  }
-
-  async startMarketWatcher() {
-    await this.refreshMarketSnapshot();
-    setInterval(() => this.refreshMarketSnapshot(), this.marketPollIntervalMs);
-  }
-
-  async refreshMarketSnapshot() {
-    try {
-      const response = await fetch(`https://api.dexscreener.com/latest/dex/pairs/polygon/${this.contracts.PAIR}`);
-      if (!response.ok) {
-        throw new Error(`DexScreener returned ${response.status}`);
-      }
-
-      const payload = await response.json();
-      const pair = payload?.pair;
-      if (!pair) {
-        throw new Error('Pair data not available yet');
-      }
-
-      const priceUsd = Number(pair.priceUsd || 0);
-      const liquidityUsd = Number(pair.liquidity?.usd || 0);
-      const volume24h = Number(pair.volume?.h24 || 0);
-      const buys24h = Number(pair.txns?.h24?.buys || 0);
-      const sells24h = Number(pair.txns?.h24?.sells || 0);
-      const priceChange24h = Number(pair.priceChange?.h24 || 0);
-      const fdv = Number(pair.fdv || 0);
-      const holderEstimate = Math.max(1, Math.round(liquidityUsd > 0 ? liquidityUsd / 100 : 1));
-      const isLive = liquidityUsd >= this.minimumLiveLiquidityUsd;
-
-      this.marketSnapshot = {
-        priceUsd,
-        liquidityUsd,
-        volume24h,
-        buys24h,
-        sells24h,
-        fdv,
-        priceChange24h,
-        holderEstimate,
-        isLive,
-        updatedAt: new Date().toISOString()
-      };
-
-      this.metrics.priceUsd = priceUsd;
-      this.metrics.liquidityUsd = liquidityUsd;
-      this.metrics.volume24h = volume24h;
-      this.metrics.holderEstimate = holderEstimate;
-
-      this.updateBanner();
-      this.broadcastMarketSnapshot();
-      this.updateExistingMarketNodes();
-    } catch (error) {
-      console.error('Market watcher error:', error);
-      this.updateBannerError(error.message);
-    }
-  }
-
-  updateBanner() {
-    const banner = document.getElementById('aetheronLiveTradingBanner');
-    if (!banner || !this.marketSnapshot) {
-      return;
-    }
-
-    banner.classList.toggle('is-live', this.marketSnapshot.isLive);
-    const headline = document.getElementById('aetheronLiveHeadline');
-    const subhead = document.getElementById('aetheronLiveSubhead');
-    const price = document.getElementById('aetheronBannerPrice');
-    const liquidity = document.getElementById('aetheronBannerLiquidity');
-    const volume = document.getElementById('aetheronBannerVolume');
-    const holders = document.getElementById('aetheronBannerHolders');
-
-    if (headline) {
-      headline.textContent = this.marketSnapshot.isLive ? 'LIVE TRADING ACTIVE' : 'Liquidity warming up';
-    }
-    if (subhead) {
-      subhead.textContent = this.marketSnapshot.isLive
-        ? `Price ${this.formatUsd(this.marketSnapshot.priceUsd)} · ${this.marketSnapshot.priceChange24h >= 0 ? '+' : ''}${this.marketSnapshot.priceChange24h.toFixed(2)}% in 24h`
-        : 'Trade links are ready. Banner switches to live once market liquidity clears the launch threshold.';
-    }
-    if (price) price.textContent = this.formatUsd(this.marketSnapshot.priceUsd, true);
-    if (liquidity) liquidity.textContent = this.compactUsd(this.marketSnapshot.liquidityUsd);
-    if (volume) volume.textContent = this.compactUsd(this.marketSnapshot.volume24h);
-    if (holders) holders.textContent = `${this.marketSnapshot.holderEstimate}+`;
-  }
-
-  updateBannerError(message) {
-    const headline = document.getElementById('aetheronLiveHeadline');
-    const subhead = document.getElementById('aetheronLiveSubhead');
-    if (headline) headline.textContent = 'Market signal unavailable';
-    if (subhead) subhead.textContent = message || 'Unable to reach DexScreener right now.';
-  }
-
-  updateExistingMarketNodes() {
-    if (!this.marketSnapshot) {
-      return;
-    }
-
-    const holdersNodes = [document.getElementById('holdersValue'), document.getElementById('liveHoldersCount')].filter(Boolean);
-    holdersNodes.forEach((node) => {
-      node.textContent = `${this.marketSnapshot.holderEstimate}+`;
-    });
-
-    const holdersChange = document.getElementById('holdersChange');
-    if (holdersChange) {
-      holdersChange.textContent = this.marketSnapshot.isLive ? 'Live market detected' : 'Awaiting live liquidity';
-    }
-  }
-
-  broadcastMarketSnapshot() {
-    window.dispatchEvent(new CustomEvent('aetheron:market-data', { detail: this.marketSnapshot }));
-  }
-
-  compactUsd(value) {
-    if (!Number.isFinite(value) || value <= 0) {
-      return '$0';
-    }
-    if (value >= 1000000) return `$${(value / 1000000).toFixed(2)}M`;
-    if (value >= 1000) return `$${(value / 1000).toFixed(1)}K`;
-    return `$${value.toFixed(0)}`;
-  }
-
-  formatUsd(value, smallAllowed = false) {
-    if (!Number.isFinite(value) || value <= 0) {
-      return '$0.00';
-    }
-    if (smallAllowed && value < 0.01) {
-      return `$${value.toFixed(8)}`;
-    }
-    return `$${value.toFixed(4)}`;
-  }
-
-  trackPageViews() {
-    this.metrics.pageViews += 1;
-    console.log('Page view tracked');
-
-    const startTime = Date.now();
-    window.addEventListener('beforeunload', () => {
-      const timeSpent = Math.round((Date.now() - startTime) / 1000);
-      this.trackEvent('time_spent', { seconds: timeSpent });
-    });
-  }
-
-  monitorWalletConnections() {
-    window.addEventListener('ethereum#initialized', () => {
-      this.metrics.walletConnections += 1;
-      this.trackEvent('wallet_connected');
-    });
-
-    if (window.ethereum) {
-      window.ethereum.on('accountsChanged', (accounts) => {
-        if (accounts.length > 0) {
-          this.trackEvent('account_changed', { address: accounts[0] });
-        }
-      });
-    }
-  }
-
-  async monitorContractActivity() {
-    try {
-      if (window.ethers && window.ethereum) {
-        const provider = new ethers.providers.Web3Provider(window.ethereum);
-
-        const aethContract = new ethers.Contract(
-          this.contracts.AETH,
-          ['event Transfer(address indexed from, address indexed to, uint256 value)'],
-          provider
-        );
-
-        aethContract.on('Transfer', (from, to, value) => {
-          this.metrics.transactions += 1;
-          this.trackEvent('aeth_transfer', {
-            from,
-            to,
-            value: ethers.utils ? ethers.utils.formatEther(value) : String(value)
-          });
-        });
-
-        const stakingContract = new ethers.Contract(
-          this.contracts.STAKING,
-          ['event Staked(address indexed user, uint256 poolId, uint256 amount)'],
-          provider
-        );
-
-        stakingContract.on('Staked', (user, poolId, amount) => {
-          this.metrics.stakingActivity += 1;
-          this.trackEvent('staking_deposit', {
-            user,
-            poolId: poolId.toString(),
-            amount: ethers.utils ? ethers.utils.formatEther(amount) : String(amount)
-          });
-        });
-      }
-    } catch (error) {
-      console.error('Contract monitoring error:', error);
-    }
-  }
-
-  setupErrorTracking() {
-    window.addEventListener('error', (event) => {
-      this.metrics.errors += 1;
-      this.trackEvent('javascript_error', {
-        message: event.message,
-        filename: event.filename,
-        lineno: event.lineno
-      });
-    });
-
-    window.addEventListener('unhandledrejection', (event) => {
-      this.metrics.errors += 1;
-      this.trackEvent('promise_rejection', {
-        reason: event.reason?.toString()
-      });
-    });
-  }
-
-  trackEvent(eventName, data = {}) {
-    const eventData = {
-      event: eventName,
-      timestamp: new Date().toISOString(),
-      userAgent: navigator.userAgent,
-      url: window.location.href,
-      ...data
-    };
-
-    console.log('Event tracked:', eventData);
-    this.sendToAnalytics(eventData);
-  }
-
-  sendToAnalytics(data) {
-    try {
-      if (typeof gtag !== 'undefined') {
-        gtag('event', data.event, {
-          custom_parameter_1: JSON.stringify(data)
-        });
-      }
-    } catch (error) {
-      console.error('Analytics error:', error);
-    }
-  }
-
-  sendMetrics() {
-    setInterval(() => {
-      this.trackEvent('platform_metrics', { ...this.metrics, market: this.marketSnapshot || null });
-    }, 5 * 60 * 1000);
-  }
-
-  getMetrics() {
-    return { ...this.metrics };
+      <div class="aetheron-live-banner__actions"><a class="aetheron-live-banner__button aetheron-live-banner__button--primary" href="${this.links.buy}">Buy AETH</a><a class="aetheron-live-banner__button" href="${this.links.presale}" target="_blank" rel="noopener noreferrer">BaseScan</a><a class="aetheron-live-banner__button" href="${this.links.token}" target="_blank" rel="noopener noreferrer">Token</a></div>`;
+    host.prepend(banner);
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  window.aetheronMonitor = new AetheronMonitor();
-});
+document.addEventListener('DOMContentLoaded', () => { window.aetheronMonitor = new AetheronMonitor(); });

--- a/vercel.json
+++ b/vercel.json
@@ -1,34 +1,21 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
-  "installCommand": "npm install",
+  "installCommand": "npm install --legacy-peer-deps",
   "buildCommand": "echo \"Static site - no build needed\"",
   "outputDirectory": ".",
   "functions": {
-    "api/**/*.mjs": {
-      "maxDuration": 60
-    }
+    "api/**/*.mjs": { "maxDuration": 60 }
   },
   "headers": [
     {
       "source": "(.*)",
       "headers": [
-        {
-          "key": "X-Content-Type-Options",
-          "value": "nosniff"
-        },
-        {
-          "key": "X-Frame-Options",
-          "value": "DENY"
-        },
-        {
-          "key": "X-XSS-Protection",
-          "value": "1; mode=block"
-        },
-        {
-          "key": "Strict-Transport-Security",
-          "value": "max-age=63072000; includeSubDomains; preload"
-        }
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+        { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" }
       ]
     }
   ]


### PR DESCRIPTION
## What changed
- replaces obsolete Polygon trading, token, explorer, and market-pair paths on the public homepage
- presents the verified Base presale as the current sale flow with the correct 0.0003 ETH minimum and 1,000,000 AETH/ETH rate
- updates QR/address and MetaMask-facing token references to the deployed Base token
- replaces the failed DexScreener market banner with an accurate verified-presale banner
- removes unsupported public claims about live staking, liquidity, holder counts, and independent audits from the homepage FAQ
- improves responsive card/address layout
- makes Vercel installs tolerate legacy dependency metadata and adds browser security headers

## Verified addresses
- AETH: `0xecf7E17faE148C01E1b5008A31Dfd2d1B6608E4e`
- Presale: `0xe0A3B6368312dFd3E7E76202e673f895f8235A3d`

## Validation
- branch is 3 commits ahead of main with only the intended three public/deployment files changed
- corrected files were fetched back from GitHub after write
- production deployment and live-domain verification will run after merge