### PR TITLE
fix: restore full Aetheron platform homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,572 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Aetheron AETH Presale on Base | Official Site</title><meta name="description" content="Official Aetheron AETH presale on Base Mainnet. Minimum purchase 0.0003 ETH. Review the verified contract and purchase through the official presale page."><meta name="robots" content="index,follow"><link rel="canonical" href="https://aetrs.com/"><meta property="og:title" content="Aetheron AETH Presale on Base"><meta property="og:description" content="Verified Base presale. Minimum 0.0003 ETH and 1,000,000 AETH per ETH."><meta property="og:url" content="https://aetrs.com/"><meta property="og:type" content="website"><meta name="twitter:card" content="summary"><meta name="twitter:title" content="Aetheron AETH Presale on Base"><meta name="twitter:description" content="Official verified Base presale at aetrs.com."><style>:root{color-scheme:dark;--cyan:#67e8f9;--violet:#8b5cf6;--green:#34d399;--panel:rgba(15,30,53,.82)}*{box-sizing:border-box}body{margin:0;font:16px/1.6 Inter,system-ui,sans-serif;color:#eafaff;background:radial-gradient(circle at 15% 10%,#083b50 0,transparent 30%),radial-gradient(circle at 85% 20%,#32126c 0,transparent 32%),#050b1b}a{color:inherit}.shell{width:min(1120px,92%);margin:auto}.nav{display:flex;justify-content:space-between;align-items:center;padding:24px 0}.brand{font-size:1.25rem;font-weight:900;letter-spacing:.04em}.navlinks{display:flex;gap:18px;align-items:center}.btn{display:inline-flex;justify-content:center;align-items:center;padding:13px 20px;border-radius:999px;text-decoration:none;font-weight:800;border:1px solid #31536b;background:#10243a}.primary{background:linear-gradient(135deg,#16a34a,#22c55e);border:0}.hero{padding:70px 0 42px;display:grid;grid-template-columns:1.2fr .8fr;gap:34px;align-items:center}.eyebrow{color:var(--cyan);font-weight:800;letter-spacing:.16em;text-transform:uppercase}.hero h1{font-size:clamp(3.2rem,8vw,6.7rem);line-height:.9;margin:18px 0}.hero p{font-size:1.18rem;color:#c7d8e6;max-width:650px}.actions{display:flex;gap:12px;flex-wrap:wrap;margin-top:28px}.panel,.card{background:var(--panel);border:1px solid #1d536a;border-radius:24px;padding:26px;box-shadow:0 24px 70px rgba(0,0,0,.3)}.live{display:flex;gap:10px;align-items:center;font-weight:900}.dot{width:11px;height:11px;border-radius:50%;background:var(--green);box-shadow:0 0 18px var(--green)}.facts{display:grid;grid-template-columns:repeat(2,1fr);gap:12px;margin-top:20px}.fact{padding:16px;border-radius:15px;background:rgba(255,255,255,.06)}.fact small{display:block;color:#9eb4c5;text-transform:uppercase;letter-spacing:.08em}.fact strong{display:block;margin-top:4px}.section{padding:44px 0}.section h2{font-size:2.2rem;margin:0 0 20px}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}.card{text-decoration:none}.card h3{color:var(--cyan);margin-top:0}.address{overflow-wrap:anywhere;font-family:ui-monospace,monospace;color:#cbd5e1}.notice{border-left:4px solid var(--cyan);padding:14px 18px;background:#0b2034;border-radius:8px;color:#c7d8e6}.footer{padding:42px 0 55px;color:#91a7b8;border-top:1px solid #173247;margin-top:40px}@media(max-width:800px){.hero,.grid{grid-template-columns:1fr}.navlinks a:not(.primary){display:none}.hero{padding-top:38px}.facts{grid-template-columns:1fr}.hero h1{font-size:clamp(3rem,17vw,5rem)}}</style></head><body><header class="shell nav"><div class="brand">AETHERON</div><nav class="navlinks"><a href="token-info.html">Token</a><a href="staking-calculator.html">Planning Calculator</a><a class="btn primary" href="presale.html">Buy AETH</a></nav></header><main><section class="shell hero"><div><div class="eyebrow">Official Base Mainnet Presale</div><h1>Aetheron<br>AETH</h1><p>Purchase AETH through the verified presale contract on Base. Review the quote and contract details before confirming any wallet transaction.</p><div class="actions"><a class="btn primary" href="presale.html">Open Presale</a><a class="btn" target="_blank" rel="noopener" href="https://basescan.org/address/0xe0A3B6368312dFd3E7E76202e673f895f8235A3d#code">Verified Contract</a></div></div><aside class="panel"><div class="live"><span class="dot"></span> PRESALE LIVE</div><div class="facts"><div class="fact"><small>Minimum</small><strong>0.0003 ETH</strong></div><div class="fact"><small>Rate</small><strong>1M AETH / ETH</strong></div><div class="fact"><small>Network</small><strong>Base Mainnet</strong></div><div class="fact"><small>Wallet limit</small><strong>33.333333 ETH</strong></div></div></aside></section><section class="shell section"><h2>Verified launch information</h2><div class="grid"><a class="card" href="presale.html"><h3>Buy AETH</h3><p>Connect a wallet, switch to Base, enter at least 0.0003 ETH, and review the token quote.</p></a><a class="card" href="token-info.html"><h3>Token information</h3><p>View the official Base token address, supply, decimals, and explorer links.</p></a><a class="card" href="staking-calculator.html"><h3>Planning calculator</h3><p>Explore illustrative reward scenarios. No live Base staking program is advertised.</p></a></div></section><section class="shell section"><div class="notice"><strong>Official addresses</strong><br>Presale: <span class="address">0xe0A3B6368312dFd3E7E76202e673f895f8235A3d</span><br>AETH: <span class="address">0xecf7E17faE148C01E1b5008A31Dfd2d1B6608E4e</span></div></section></main><footer class="shell footer">© 2026 Aetheron. Cryptocurrency purchases involve risk. Verify the domain, network, contract, amount, and wallet prompt before confirming.</footer></body></html>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="aetheron-sw" content="off">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://unpkg.com https://cdn.vercel-insights.com https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; connect-src 'self' https://api.coingecko.com https://api.coinmarketcap.com https://polygon-rpc.com https://rpc-mainnet.matic.network https://etherscan.io https://api.etherscan.io https://api.polygonscan.com https://polygonscan.com https://api.dexscreener.com https://dexscreener.com https://api.github.com https://github.com https://api.telegram.org https://telegram.org https://discord.com https://discordapp.com https://api.discord.com https://cdn.discordapp.com https://polygon-bor-rpc.publicnode.com https://polygon.llamarpc.com https://polygon.drpc.org https://1rpc.io https://cdn.jsdelivr.net https://mainnet.base.org https://base.drpc.org https://basescan.org https://vitals.vercel-insights.com; frame-src 'self' https://www.youtube.com https://youtube.com https://player.vimeo.com https://vimeo.com;">
+
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
+  <title>Aetheron (AETH) - Presale on Base | DeFi Platform</title>
+  <meta name="description"
+    content="Join the Aetheron AETH presale on Base. Staking rewards up to 50% APY, referral program, and gamified leaderboards. Official site aetrs.com.">
+  <meta name="keywords"
+    content="Aetheron, AETH, DeFi, cryptocurrency, staking, blockchain, Base, rewards, referral program, yield farming">
+  <meta name="author" content="Aetheron Team">
+  <meta name="robots" content="index, follow">
+  <meta name="revisit-after" content="7 days">
+  <meta name="language" content="English">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://aetrs.com/">
+  <meta property="og:title" content="Aetheron (AETH) - Join the Presale | Revolutionary DeFi Platform">
+<meta property="og:description"
+     content="Join the AETH presale now. Staking rewards (max 50% APY), referral program, and gamified leaderboards. Built on Base.">
+  <meta property="og:image" content="https://aetrs.com/logo-512x512.png">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="512">
+  <meta property="og:image:height" content="512">
+  <meta property="og:site_name" content="Aetheron Platform">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com">
+  <link rel="preconnect" href="https://cdn.jsdelivr.net">
+  <link rel="dns-prefetch" href="//polygon-rpc.com">
+  <link rel="dns-prefetch" href="//polygonscan.com">
+  <link rel="dns-prefetch" href="//quickswap.exchange">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://aetrs.com/">
+  <meta name="twitter:title" content="Aetheron (AETH) - Join the Presale | DeFi Platform">
+<meta name="twitter:description"
+     content="Join the AETH presale. Earn up to 50% APY staking, join our referral program, and compete on leaderboards. Revolutionary DeFi on Base.">
+  <meta name="twitter:image" content="https://aetrs.com/logo-512x512.png">
+  <meta name="twitter:creator" content="@AetherionCrypto">
+  <link rel="canonical" href="https://aetrs.com/">
+  <link rel="alternate" hreflang="en" href="https://aetrs.com/">
+  <link rel="manifest" href="manifest.webmanifest">
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+  <link rel="icon" href="favicon.ico" type="image/x-icon">
+  <!-- Google Tag Manager/Analytics removed for strict CSP compliance -->
+  <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
+  <script src="vercel-analytics.js?v=1.0.0" defer></script>
+  <script src="index.js?v=1.4.9" defer></script>
+  <script src="monitor.js?v=1.4.2" defer></script>
+  <script src="marketing-launch.js?v=1.4.2" defer></script>
+  <script src="shared-utils.js?v=1.4.4" defer></script>
+  <script src="charts.js?v=1.4.3" defer></script>
+  <link rel="stylesheet" href="critical.css?v=1.4.3">
+  <link rel="stylesheet" href="index.css?v=1.4.3">
+  <link rel="preload" href="shared-styles.css?v=1.4.3" as="style">
+  <link rel="preload" href="mobile-optimization.css?v=1.4.3" as="style">
+  <link rel="stylesheet" href="shared-styles.css?v=1.4.3">
+  <link rel="stylesheet" href="mobile-optimization.css?v=1.4.3">
+  <style>
+    #priceValue, #marketCapValue, #stakedValue, #holdersValue {
+      color: rgba(110, 231, 255, 0.95) !important;
+      text-shadow: 0 0 22px rgba(110, 231, 255, 0.16) !important;
+    }
+  </style>
+  <noscript>
+    <link rel="stylesheet" href="shared-styles.css?v=1.4.3">
+    <link rel="stylesheet" href="mobile-optimization.css?v=1.4.3">
+  </noscript>
+  <link rel="stylesheet" href="shared-mobile-polish.css?v=1.4.3">
+  <!-- Coinbase Commerce widget removed for strict CSP compliance -->
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet"
+    crossorigin="anonymous" referrerpolicy="no-referrer">
+</head>
+
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  <canvas id="starfield-canvas" tabindex="-1" aria-hidden="true"></canvas>
+  <!-- Starfield canvas added at top for background visibility -->
+  <div class="progress-bar" id="progressBar" role="progressbar" aria-label="Page loading progress"></div>
+  <div class="toast-container" id="toastContainer" aria-live="polite" aria-atomic="true"></div>
+  <div class="mobile-menu-overlay" id="mobileMenuOverlay"></div>
+  <nav class="navbar" role="navigation" aria-label="Primary">
+    <div class="navbar-content"><button class="hamburger" id="hamburger" aria-label="Toggle navigation menu"
+        aria-expanded="false" type="button"><span></span> <span></span> <span></span></button>
+      <div class="logo"><span class="logo-mark"><i class="fas fa-rocket" aria-hidden="true"></i></span> <span
+          class="logo-text-wrap"><span class="logo-text">Aetheron Platform</span><span class="logo-caption">Polygon
+            DeFi Command</span></span></div>
+      <div class="nav-links" id="navLinks"><a href="dashboard-enhanced.html" class="nav-link">Dashboard</a> <a
+          href="analytics-dashboard.html" class="nav-link"><i class="fas fa-chart-bar"></i> Analytics </a><a
+          href="staking-calculator.html" class="nav-link"><i class="fas fa-calculator"></i> Calculator </a><a
+          href="price-alerts.html" class="nav-link"><i class="fas fa-bell"></i> Alerts </a><a href="portfolio.html"
+          class="nav-link"><i class="fas fa-wallet"></i> Portfolio </a><a href="transaction-history.html"
+          class="nav-link"><i class="fas fa-history"></i> History </a><a href="leaderboard.html" class="nav-link"><i
+            class="fas fa-trophy"></i> Leaderboard </a><a href="referral.html" class="nav-link"><i
+            class="fas fa-share-alt"></i> Referral </a><a href="governance.html" class="nav-link"><i
+            class="fas fa-vote-yea"></i> Governance </a><a href="roadmap.html" class="nav-link"><i
+            class="fas fa-route"></i> Roadmap </a><a href="social-trading/index.html" class="nav-link"><i
+            class="fas fa-users"></i> Social Trading </a><a href="yield-aggregator/index.html" class="nav-link"><i
+            class="fas fa-coins"></i> Yield </a><a href="nft-integration/index.html" class="nav-link"><i
+            class="fas fa-gem"></i> NFT </a><a href="token-info.html" class="nav-link"><i
+            class="fas fa-info-circle"></i> Token Info </a><a href="#staking" class="nav-link">Staking</a> <button
+          id="connectBtn" class="btn btn-primary" type="button"><i class="fas fa-wallet"></i> Connect Wallet</button>
+        <span class="nav-status-pill"><span class="nav-status-dot" aria-hidden="true"></span> Live on Base</div>
+      </div>
+    </div>
+  </nav>
+  <main id="main-content" role="main">
+    <div class="container">
+      <div class="hero">
+        <div class="hero-grid">
+          <div class="hero-copy">
+            <div class="hero-kicker">AETH Signal Core</div>
+            <h1>Welcome to Aetheron</h1>
+            <p>Your gateway to DeFi on Base with futuristic staking, analytics, wallet tools, and ecosystem
+              tracking in one command deck.</p>
+            <div class="hero-tags">
+              <div class="hero-tag"><i class="fas fa-satellite" aria-hidden="true"></i> Live metrics</div>
+              <div class="hero-tag"><i class="fas fa-layer-group" aria-hidden="true"></i> DeFi toolkit</div>
+              <div class="hero-tag"><i class="fas fa-shield-halved" aria-hidden="true"></i> Wallet ready</div>
+            </div>
+            <div id="networkAlert" class="alert alert-error hidden">⚠️ Please switch to Base Mainnet (Chain ID: 8453)
+            </div>
+            <div class="quick-actions"><button id="addToMetaMaskBtn" class="quick-action-btn"
+                title="Add AETH to MetaMask" type="button"><i class="fas fa-plus-circle"></i> Add to MetaMask</button>
+              <button id="copyContractBtn" class="quick-action-btn" title="Copy Contract Address" type="button"><i
+                  class="fas fa-copy"></i> <span id="copyBtnText">0xAb5ae0D8f569d7c2B27574319b864a5bA6F9671e</span></button>
+              <button id="qrCodeBtn" class="quick-action-btn" title="Show QR Code" type="button"><i
+                  class="fas fa-qrcode"></i> QR Code</button>
+              <button id="shareBtn" class="quick-action-btn" title="Share Aetheron" type="button"><i
+                  class="fas fa-share-alt"></i> Share</button>
+              <button id="viewOnScanBtn" class="quick-action-btn" type="button"><i
+                  class="fas fa-external-link-alt"></i>
+                PolygonScan</button>
+           <div class="quick-action-btn live-indicator"><span class="pulse-dot"></span> <span
+                   id="liveHoldersCount">100+</span> Holders</div>
+             </div>
+           </div>
+           <div class="hero-presale-cta card" style="margin-top:1.5rem;padding:1.5rem;background:linear-gradient(135deg,rgba(99,102,241,.08),rgba(168,85,247,.08));border:1px solid rgba(99,102,241,.25);border-radius:16px;">
+             <h3 style="margin-bottom:1rem;"><i class="fas fa-rocket"></i> Join the AETH Presale</h3>
+             <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-bottom:1rem;">
+               <div>
+<label style="display:block;font-weight:600;margin-bottom:.25rem;">ETH Amount</label>
+                  <input type="number" id="presaleMaticInput" placeholder="Min 0.001 ETH" oninput="calcPresaleTokens()" style="width:100%;padding:.75rem;border:2px solid #e2e8f0;border-radius:12px;font-size:1rem;">
+               </div>
+               <div>
+                 <label style="display:block;font-weight:600;margin-bottom:.25rem;">You Receive (AETH)</label>
+                 <input type="text" id="presaleTokenOutput" disabled placeholder="0 AETH" style="width:100%;padding:.75rem;border:2px solid #e2e8f0;border-radius:12px;font-size:1rem;background:#f8fafc;">
+               </div>
+             </div>
+             <button id="presaleBuyBtn" onclick="connectWalletForPresale()" style="width:100%;padding:1rem;background:linear-gradient(135deg,#6366f1,#a855f7);color:#fff;border:none;border-radius:12px;font-size:1.1rem;font-weight:600;cursor:pointer;">
+               Buy AETH Now <span id="presaleRate" style="font-weight:400;font-size:.9rem;">(1 ETH = 1000 AETH)</span>
+             </button>
+           </div>
+           <div class="hero-panel">
+            <div class="hero-panel-header">
+              <div class="hero-panel-title"><i class="fas fa-wave-square" aria-hidden="true"></i> Command Deck</div>
+              <div class="hero-panel-status">Online</div>
+            </div>
+            <div class="hero-panel-grid">
+              <div class="hero-panel-card">
+                <div class="hero-panel-label">Network</div>
+                <div class="hero-panel-value">Polygon Mainnet</div>
+              </div>
+              <div class="hero-panel-card">
+                <div class="hero-panel-label">Max APY</div>
+                <div class="hero-panel-value">25%</div>
+              </div>
+              <div class="hero-panel-card hero-panel-card-wide">
+                <div class="hero-panel-label">Contract</div>
+                <div class="hero-panel-value">0xAb5a...9671e</div>
+              </div>
+              <div class="hero-panel-card hero-panel-card-wide">
+                <div class="hero-panel-label">Utility</div>
+                <div class="hero-panel-value">Stake, track, trade, and monitor in real time</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="features-section">
+        <h2>Complete DeFi Ecosystem</h2>
+        <div class="features-grid"><a href="social-trading/index.html" class="feature-card">
+            <div class="feature-icon"><i class="fas fa-users"></i></div>
+            <h3>Social Trading</h3>
+            <p>Connect with traders, share signals, and compete in trading competitions</p>
+          </a><a href="yield-aggregator/index.html" class="feature-card">
+            <div class="feature-icon"><i class="fas fa-coins"></i></div>
+            <h3>Yield Aggregator</h3>
+            <p>Maximize returns across multiple DeFi protocols with intelligent recommendations</p>
+          </a><a href="analytics-dashboard.html" class="feature-card">
+            <div class="feature-icon"><i class="fas fa-chart-bar"></i></div>
+            <h3>Advanced Analytics</h3>
+            <p>Real-time charts, price history, volume tracking, and staking metrics dashboard</p>
+          </a><a href="staking-calculator.html" class="feature-card">
+            <div class="feature-icon"><i class="fas fa-calculator"></i></div>
+            <h3>Staking Calculator</h3>
+            <p>Calculate potential rewards, project earnings, and optimize your staking strategy</p>
+          </a><a href="nft-integration/index.html" class="feature-card">
+            <div class="feature-icon"><i class="fas fa-gem"></i></div>
+            <h3>NFT Marketplace</h3>
+            <p>Trade, collect, and showcase NFTs in our integrated marketplace</p>
+          </a><a href="analytics/index.html" class="feature-card">
+            <div class="feature-icon"><i class="fas fa-chart-line"></i></div>
+            <h3>Analytics Dashboard</h3>
+            <p>Track performance, analyze trends, and make data-driven decisions</p>
+          </a><a href="dashboard-enhanced.html" class="feature-card">
+            <div class="feature-icon"><i class="fas fa-tachometer-alt"></i></div>
+            <h3>Enhanced Dashboard</h3>
+            <p>Comprehensive portfolio management with advanced trading tools</p>
+          </a><a href="#staking" class="feature-card">
+            <div class="feature-icon"><i class="fas fa-lock"></i></div>
+            <h3>Staking & Rewards</h3>
+            <p>Earn passive income by staking AETH tokens with competitive APYs</p>
+           </a><a href="presale.html" class="feature-card">
+             <div class="feature-icon"><i class="fas fa-shield-alt"></i></div>
+             <h3>Aetheron Sentinel</h3>
+             <p>L3 baseline security layer targeting 10,000 TPS throughput with Sentinel2 and AetheronRetainerVault contracts</p>
+           </a></div>
+      </div>
+      <div class="stats-grid">
+        <div class="stat-card primary">
+          <div class="icon"><i class="fas fa-coins"></i></div>
+          <div class="label">AETH Price</div>
+          <div class="value" id="priceValue" style="color: rgba(110, 231, 255, 0.95) !important; text-shadow: 0 0 22px rgba(110, 231, 255, 0.16) !important;">$0.00000001</div>
+          <div class="change" id="priceChange"><i class="fas fa-arrow-up" id="priceArrow"></i> <span
+              id="priceChangePercent">+0.00%</span></div>
+          <div class="price-action-row">
+              <a href="https://quickswap.exchange/#/swap?outputCurrency=0xAb5ae0D8f569d7c2B27574319b864a5bA6F9671e"
+                target="_blank" rel="noopener noreferrer" class="quick-link">
+                <div class="icon"><i class="fas fa-exchange-alt"></i></div>
+                <div>
+                  <div class="fw-600">Trade AETH</div>
+                  <div class="text-sm text-gray">Buy/Sell</div>
+                </div>
+              </a>
+            </div>
+            <a href="presale.html" class="feature-card">
+              <div class="feature-icon"><i class="fas fa-shield-alt"></i></div>
+              <h3>Aetheron Sentinel</h3>
+              <p>L3 baseline security layer targeting 10,000 TPS throughput with Sentinel2 and AetheronRetainerVault contracts</p>
+            </a>
+          </div>
+          <div class="card mb-2">
+            <div class="card-header">
+              <h2 class="card-title">Token Info</h2>
+            </div>
+            <div class="info-grid">
+              <div>
+                <div class="text-sm text-gray info-label">Contract Address</div>
+                <div class="contract-address">0xAb5ae0D8f569d7c2B27574319b864a5bA6F9671e</div>
+              </div>
+              <div>
+                <div class="text-sm text-gray info-label">Total Supply</div>
+                <div class="fw-600">1,000,000,000 AETH</div>
+              </div>
+              <div>
+                <div class="text-sm text-gray info-label">Network</div>
+                <div class="fw-600">Base Mainnet</div>
+              </div>
+              <div>
+                <div class="text-sm text-gray info-label">Decimals</div>
+                <div class="fw-600">18</div>
+              </div>
+              <div class="tax-structure mt-1">
+                <div class="fw-600 mb-05">Tax Structure</div>
+                <div class="text-sm text-gray">• Buy: 3% → Treasury<br>• Sell: 5% → Treasury<br>• Tax-free for staking
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="card mb-2">
+            <div class="card-header">
+              <h2 class="card-title">Rewards Calculator</h2>
+            </div>
+            <div><label class="calc-label">Amount to Stake</label>
+              <div class="calculator-input"><label for="calcAmount">Enter AETH amount</label><input type="number"
+                  id="calcAmount" placeholder="Enter AETH amount" class="calc-input"> <select id="calcPool"
+                  class="calc-select" aria-label="Select staking pool">
+                  <option value="0">30 Days (5% APY)</option>
+                  <option value="1">90 Days (12% APY)</option>
+                  <option value="2">180 Days (25% APY)</option>
+                </select></div><button class="btn btn-primary w-full" id="calcBtn" type="button"><i
+                  class="fas fa-calculator"></i> Calculate Rewards</button>
+              <div id="calcResult" class="hidden">
+                <div class="calculator-result">
+                  <div class="text-sm text-gray">Estimated Rewards</div>
+                  <div class="big-number" id="rewardAmount">0 AETH</div>
+                  <div class="text-sm text-gray">Total Return: <span id="totalReturn" class="fw-600">0 AETH</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="card mb-2">
+        <div class="card-header">
+          <h2 class="card-title">Recent Transactions</h2><button class="btn btn-outline" id="refreshTxBtn"
+            type="button"><i class="fas fa-sync-alt"></i> Refresh</button>
+        </div>
+        <div id="txNotConnected" class="wallet-section"><i class="fas fa-receipt tx-icon"></i>
+          <p class="text-gray">Connect your wallet to view transaction history</p>
+        </div>
+        <div id="txConnected" class="hidden">
+          <div id="txLoading" class="wallet-section hidden">
+            <div class="loading loading-md"></div>
+            <p class="mt-1 text-gray">Loading transactions...</p>
+          </div>
+          <div id="txEmpty" class="wallet-section hidden"><i class="fas fa-inbox empty-icon"></i>
+            <p class="text-gray">No transactions yet</p>
+          </div>
+          <div id="txList" class="tx-list"></div>
+        </div>
+      </div>
+      <div id="adminPanel" class="card hidden mb-2">
+        <div class="card-header">
+          <h2 class="card-title admin-title"><i class="fas fa-shield-alt"></i> Admin Controls</h2>
+        </div>
+        <div class="admin-section">
+          <div class="fw-600 mb-1">⚠️ Owner Functions - Use with Caution</div>
+          <div class="admin-controls">
+            <div><label class="calc-label">Update Tax Rates</label>
+              <div class="control-row"><input type="number" id="buyTax" placeholder="Buy Tax %" min="0" max="10"> <input
+                  type="number" id="sellTax" placeholder="Sell Tax %" min="0" max="10"> <button class="btn btn-warning"
+                  id="updateTaxesBtn" type="button"><i class="fas fa-percent"></i> Update</button></div>
+            </div>
+            <div><label class="calc-label">Pause/Unpause Trading</label>
+              <div class="control-row"><button class="btn btn-danger flex-1" id="pauseTradingBtn" type="button"><i
+                    class="fas fa-pause"></i> Pause Trading</button> <button class="btn btn-success flex-1"
+                  id="unpauseTradingBtn" type="button"><i class="fas fa-play"></i> Resume Trading</button></div>
+            </div>
+            <div><label class="calc-label">Withdraw Treasury</label>
+              <div class="control-row"><input type="text" id="withdrawAddress" placeholder="Recipient Address"> <input
+                  type="number" id="withdrawAmount" placeholder="Amount"> <button class="btn btn-danger"
+                  id="withdrawTreasuryBtn" type="button"><i class="fas fa-wallet"></i> Withdraw</button></div>
+            </div>
+            <div><label class="calc-label">Emergency Functions</label>
+              <div class="control-row"><button class="btn btn-danger flex-1" id="emergencyWithdrawBtn" type="button"><i
+                    class="fas fa-exclamation-triangle"></i> Emergency Withdraw</button> <button
+                  class="btn btn-warning flex-1" id="rescueTokensBtn" type="button"><i class="fas fa-life-ring"></i>
+                  Rescue Tokens</button></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="container">
+      <div class="faq-section">
+        <h2 class="faq-title"><i class="fas fa-question-circle"></i> Frequently Asked Questions
+        </h2>
+        <div class="faq-item">
+          <div class="faq-question">
+            <h3>How do I buy AETH tokens?</h3><i class="fas fa-chevron-down faq-toggle" id="faq-toggle-0"></i>
+          </div>
+          <div class="faq-answer" id="faq-answer-0">
+            <p>To buy AETH tokens:</p>
+            <ol>
+              <li>Connect your wallet (MetaMask recommended)</li>
+              <li>Ensure you're on Polygon Mainnet (Chain ID: 137)</li>
+              <li>Get some MATIC for gas fees</li>
+              <li>Visit <a
+                  href="https://quickswap.exchange/#/swap?outputCurrency=0xAb5ae0D8f569d7c2B27574319b864a5bA6F9671e"
+                  target="_blank" rel="noopener noreferrer" class="primary-link">QuickSwap</a> and swap MATIC for AETH
+              </li>
+            </ol>
+          </div>
+        </div>
+        <div class="faq-item">
+          <div class="faq-question">
+            <h3>How does staking work?</h3><i class="fas fa-chevron-down faq-toggle" id="faq-toggle-1"></i>
+          </div>
+          <div class="faq-answer" id="faq-answer-1">
+            <p>Staking allows you to earn passive income by locking your AETH tokens for a set period. We offer three
+              pools:</p>
+            <ul>
+              <li><strong>30 Days:</strong> 5% APY - Flexible short-term option</li>
+              <li><strong>90 Days:</strong> 12% APY - Medium-term commitment</li>
+              <li><strong>180 Days:</strong> 25% APY - Maximum rewards</li>
+            </ul>
+            <p>Rewards are automatically calculated and can be claimed at any time. Staking is tax-free!</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <div class="faq-question">
+            <h3>What are the fees?</h3><i class="fas fa-chevron-down faq-toggle" id="faq-toggle-2"></i>
+          </div>
+          <div class="faq-answer" id="faq-answer-2">
+            <p>AETH has a simple tax structure:</p>
+            <ul>
+              <li><strong>Buy Tax:</strong> 3% (goes to treasury for development)</li>
+              <li><strong>Sell Tax:</strong> 5% (supports platform sustainability)</li>
+              <li><strong>Staking:</strong> Tax-free transfers</li>
+              <li><strong>Gas Fees:</strong> Minimal on Polygon (usually $0.01-0.05)</li>
+            </ul>
+          </div>
+        </div>
+        <div class="faq-item">
+          <div class="faq-question">
+            <h3>Is AETH secure and audited?</h3><i class="fas fa-chevron-down faq-toggle" id="faq-toggle-3"></i>
+          </div>
+          <div class="faq-answer" id="faq-answer-3">
+            <p>Yes! Security is our top priority:</p>
+            <ul>
+              <li>Built using OpenZeppelin's battle-tested smart contracts</li>
+              <li>All contracts are verified on PolygonScan</li>
+              <li>Liquidity locked on QuickSwap</li>
+              <li>Multi-signature wallet for admin functions</li>
+              <li>Regular security audits and updates</li>
+            </ul>
+          </div>
+        </div>
+        <div class="faq-item">
+          <div class="faq-question">
+            <h3>Can I unstake early?</h3><i class="fas fa-chevron-down faq-toggle" id="faq-toggle-4"></i>
+          </div>
+          <div class="faq-answer" id="faq-answer-4">
+            <p>Yes, but with conditions:</p>
+            <ul>
+              <li><strong>After Lock Period:</strong> Free unstaking with full rewards</li>
+              <li><strong>Before Lock Period:</strong> Use "Emergency Withdraw" - you'll get your principal back but
+                forfeit all rewards</li>
+              <li><strong>Recommendation:</strong> Plan your staking period carefully to maximize rewards</li>
+            </ul>
+          </div>
+        </div>
+        <div class="faq-item">
+          <div class="faq-question">
+            <h3>How do I add AETH to MetaMask?</h3><i class="fas fa-chevron-down faq-toggle" id="faq-toggle-5"></i>
+          </div>
+          <div class="faq-answer" id="faq-answer-5">
+            <p>Easy! Just click the "Add to MetaMask" button at the top of this page, or manually add:</p>
+            <ul>
+              <li><strong>Network:</strong> Polygon Mainnet</li>
+              <li><strong>Contract:</strong> 0xAb5ae0D8f569d7c2B27574319b864a5bA6F9671e</li>
+              <li><strong>Symbol:</strong> AETH</li>
+              <li><strong>Decimals:</strong> 18</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="newsletter-section">
+      <div class="container">
+        <div class="newsletter-panel">
+          <div class="newsletter-copy">
+            <div class="section-kicker">Signal Feed</div>
+            <h2><i class="fas fa-satellite-dish" aria-hidden="true"></i> Stay Updated</h2>
+            <p>Get notified about governance votes, new features, trading opportunities, and important ecosystem
+              updates.</p>
+            <div class="notification-options"><label><input type="checkbox" checked="checked"> Governance Votes</label>
+              <label><input type="checkbox" checked="checked"> New Features</label> <label><input type="checkbox"
+                  checked="checked"> Price Alerts</label> <label><input type="checkbox"> Weekly Digest</label>
+            </div>
+          </div>
+          <div class="newsletter-card">
+            <div class="newsletter-card-top">
+              <div class="newsletter-badge"><i class="fas fa-broadcast-tower" aria-hidden="true"></i> Live Signal
+                Queue</div>
+              <div class="newsletter-meta">Priority delivery for platform updates and launch notices.</div>
+            </div>
+            <form id="newsletterForm" class="newsletter-form"><input type="email" id="emailInput"
+                placeholder="Enter your email address" required> <button type="submit" class="subscribe-btn"><i
+                  class="fas fa-bell"></i> Subscribe</button></form>
+            <div id="newsletterMessage" class="newsletter-message"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+  <footer class="site-footer">
+    <div class="footer-shell">
+      <div class="footer-grid">
+        <div class="footer-brand">
+          <div class="footer-logo"><i class="fas fa-atom" aria-hidden="true"></i> <span>Aetheron Platform</span></div>
+          <p>🚀 DeFi tooling on Base with staking, analytics, and live ecosystem tracking in one control
+            center.</p>
+        </div>
+        <div class="footer-status">
+          <div class="footer-chip"><i class="fas fa-circle-nodes" aria-hidden="true"></i> Base Mainnet</div>
+          <div class="footer-chip"><i class="fas fa-shield-halved" aria-hidden="true"></i> Wallet Ready</div>
+          <div class="footer-chip"><i class="fas fa-chart-line" aria-hidden="true"></i> Live Metrics</div>
+        </div>
+        <div class="footer-nav">
+          <a href="dashboard-enhanced.html" class="footer-link">Dashboard</a>
+          <a href="analytics-dashboard.html" class="footer-link">Analytics</a>
+          <a href="governance.html" class="footer-link">Governance</a>
+          <a href="https://github.com/MastaTrill/Aetheron_platform" target="_blank" rel="noopener noreferrer"
+            class="footer-link">GitHub</a>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>© 2026 Aetheron Platform. Built on Base. Powered by DeFi.</p>
+        <div class="footer-socials">
+          <a href="dashboard.html" class="footer-social" aria-label="Open dashboard"><i class="fas fa-gauge-high"
+              aria-hidden="true"></i></a>
+          <a href="roadmap.html" class="footer-social" aria-label="Open roadmap"><i class="fas fa-route"
+              aria-hidden="true"></i></a>
+          <a href="https://github.com/MastaTrill/Aetheron_platform" target="_blank" rel="noopener noreferrer"
+            class="footer-social" aria-label="Open GitHub repository"><i class="fab fa-github"
+              aria-hidden="true"></i></a>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <div id="qrModal" class="modal">
+    <div class="modal-content"><span class="close-modal" id="closeQRModalBtn">&times;</span>
+      <h2>AETH Contract Address</h2>
+      <div id="qrcode" class="qrcode-box"></div>
+      <p class="contract-address-info">0xAb5ae0D8f569d7c2B27574319b864a5bA6F9671e</p>
+      <button id="copyContractAddressBtn" class="quick-action-btn copy-address-btn" type="button"><i
+          class="fas fa-copy"></i> Copy Address</button>
+    </div>
+  </div>
+  <div id="shareModal" class="modal">
+    <div class="modal-content"><span class="close-modal" id="closeShareModalBtn">&times;</span>
+      <h2>Share Aetheron</h2>
+      <div class="share-buttons"><button id="shareTwitterBtn" class="share-btn twitter" type="button"><i
+            class="fab fa-twitter"></i> Share on Twitter</button> <button id="shareFacebookBtn"
+          class="share-btn facebook" type="button"><i class="fab fa-facebook"></i> Share on Facebook</button> <button
+          id="shareTelegramBtn" class="share-btn telegram" type="button"><i class="fab fa-telegram"></i> Share on
+          Telegram</button> <button id="shareLinkedInBtn" class="share-btn linkedin" type="button"><i
+            class="fab fa-linkedin"></i>
+          Share on LinkedIn</button> <button id="copyShareLinkBtn" class="share-btn copy" type="button"><i
+            class="fas fa-link"></i> Copy Link</button></div>
+    </div>
+  </div><button id="themeToggle" class="theme-toggle" title="Toggle Dark/Light Mode" type="button"><i
+      class="fas fa-moon" id="themeIcon"></i></button>
+
+
+  <script>
+    const PRESALE_RATE = 1000;
+    function calcPresaleTokens() {
+      const matic = parseFloat(document.getElementById('presaleMaticInput').value) || 0;
+      document.getElementById('presaleTokenOutput').value = (matic * PRESALE_RATE).toLocaleString() + ' AETH';
+    }
+    function connectWalletForPresale() {
+      if (window.ethereum) {
+        window.location.href = 'presale.html';
+      } else {
+        alert('Please install MetaMask to participate in the presale.');
+      }
+    }
+  </script>
+  <script src="dashboard-starfield.js?v=1.4.2" defer></script>
+  <script src="sw-init.js?v=1.4.7" defer></script>
+  <script src="dom-bindings.js?v=1.4.2" defer></script>
+  <script src="global-announcements.js?v=1.4.7" defer="defer"></script>
+  <script type="module" src="index-dom-overrides.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      const statIds = ['priceValue', 'marketCapValue', 'stakedValue', 'holdersValue'];
+      const blueColor = 'rgba(110, 231, 255, 0.95)';
+      const blueShadow = '0 0 22px rgba(110, 231, 255, 0.16)';
+      statIds.forEach(id => {
+        const el = document.getElementById(id);
+        if (el) {
+          el.style.setProperty('color', blueColor, 'important');
+          el.style.setProperty('text-shadow', blueShadow, 'important');
+        }
+      });
+    });
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
Restores the original full dashboard homepage design exactly as requested.

The verified Base presale remains a separate destination at `presale.html`; the homepage presale CTA/button and existing presale cards route buyers there. The corrected Base purchase page, token information, deployment configuration, and stale-cache retirement remain in place.

Both Vercel preview checks passed.