### PR TITLE
Fix white dashboard navbar and Base branding

### DIFF
--- a/global-announcements.js
+++ b/global-announcements.js
@@ -1,10 +1,44 @@
+function enforceDashboardBranding() {
+  const styleId = 'aetheron-dark-navbar-fix';
+  if (!document.getElementById(styleId)) {
+    const style = document.createElement('style');
+    style.id = styleId;
+    style.textContent = `
+      .navbar,
+      [data-theme="light"] .navbar {
+        background: linear-gradient(180deg, rgba(3, 9, 22, 0.97), rgba(7, 14, 30, 0.94)) !important;
+        border-bottom: 1px solid rgba(110, 231, 255, 0.16) !important;
+        color: #d9fdff !important;
+        box-shadow: 0 14px 34px rgba(0, 0, 0, 0.3), inset 0 -1px 0 rgba(255, 255, 255, 0.04) !important;
+      }
+      .navbar .logo,
+      .navbar .logo-text,
+      [data-theme="light"] .navbar .logo,
+      [data-theme="light"] .navbar .logo-text { color: #d9fdff !important; }
+      .navbar .logo-caption,
+      [data-theme="light"] .navbar .logo-caption { color: rgba(188, 247, 255, 0.7) !important; }
+      .navbar .nav-link,
+      [data-theme="light"] .navbar .nav-link { color: rgba(225, 251, 255, 0.78) !important; }
+      .navbar .nav-link i,
+      [data-theme="light"] .navbar .nav-link i { color: rgba(110, 231, 255, 0.92) !important; }
+    `;
+    document.head.appendChild(style);
+  }
+
+  document.querySelectorAll('.logo-caption').forEach((caption) => {
+    if (/polygon/i.test(caption.textContent)) caption.textContent = 'Base DeFi Command';
+  });
+}
+
+enforceDashboardBranding();
+
 function initGlobalAnnouncements() {
   const ANNOUNCEMENT_STORAGE_KEY = 'aethAnnouncementDismissed';
   const OFFLINE_TOAST_KEY = 'aethOfflineReadyShown';
 
   const scriptElement = document.currentScript || document.querySelector('script[src*="global-announcements.js"]');
-  const scriptSrc = scriptElement ? (scriptElement.getAttribute('src') || 'global-announcements.js') : 'global-announcements.js';
-  const basePath = scriptSrc.replace('global-announcements.js', '');
+  const scriptUrl = new URL(scriptElement?.src || 'global-announcements.js', document.baseURI);
+  const basePath = scriptUrl.pathname.slice(0, scriptUrl.pathname.lastIndexOf('/') + 1);
   const announcementsUrl = `${basePath}announcements.json`;
   const dashboardUrl = `${basePath}dashboard.html`;
   const serviceWorkerUrl = `${basePath}service-worker.js`;
@@ -37,7 +71,6 @@ function initGlobalAnnouncements() {
 
   const toastContainer = document.createElement('div');
   toastContainer.className = 'global-toast-container';
-
   let deferredInstallPrompt = null;
 
   function showToast(message) {
@@ -45,10 +78,7 @@ function initGlobalAnnouncements() {
     toast.className = 'global-toast';
     toast.textContent = message;
     toastContainer.appendChild(toast);
-    setTimeout(() => {
-      toast.classList.add('visible');
-    }, 10);
-
+    setTimeout(() => toast.classList.add('visible'), 10);
     setTimeout(() => {
       toast.classList.remove('visible');
       setTimeout(() => toast.remove(), 300);
@@ -56,20 +86,13 @@ function initGlobalAnnouncements() {
   }
 
   function applyAnnouncement(data) {
-    if (!data || !Array.isArray(data.announcements) || data.announcements.length === 0) {
-      return;
-    }
-
+    if (!data || !Array.isArray(data.announcements) || data.announcements.length === 0) return;
     const announcement = data.announcements[0];
     const title = banner.querySelector('#globalAnnouncementTitle');
     const text = banner.querySelector('#globalAnnouncementText');
     const link = banner.querySelector('#globalAnnouncementLink');
-
     const rawHref = announcement.linkHref || dashboardUrl;
-    const resolvedHref = rawHref.startsWith('http') || rawHref.startsWith('/')
-      ? rawHref
-      : `${basePath}${rawHref}`;
-
+    const resolvedHref = rawHref.startsWith('http') || rawHref.startsWith('/') ? rawHref : `${basePath}${rawHref}`;
     title.textContent = announcement.title || 'Aetheron Updates';
     text.textContent = announcement.text || 'Latest platform updates will appear here.';
     link.textContent = announcement.linkText || 'View Dashboard';
@@ -77,23 +100,15 @@ function initGlobalAnnouncements() {
   }
 
   function hydrateAnnouncements() {
-    fetch(announcementsUrl)
-      .then((response) => (response.ok ? response.json() : null))
-      .then((data) => applyAnnouncement(data))
-      .catch(() => {});
+    fetch(announcementsUrl).then((response) => response.ok ? response.json() : null).then(applyAnnouncement).catch(() => {});
   }
 
   function registerAnnouncementDismiss() {
-    const dismissButton = banner.querySelector('#globalAnnouncementDismiss');
-    dismissButton.addEventListener('click', () => {
+    banner.querySelector('#globalAnnouncementDismiss').addEventListener('click', () => {
       localStorage.setItem(ANNOUNCEMENT_STORAGE_KEY, 'true');
       banner.remove();
     });
-
-    const dismissed = localStorage.getItem(ANNOUNCEMENT_STORAGE_KEY);
-    if (dismissed === 'true') {
-      banner.remove();
-    }
+    if (localStorage.getItem(ANNOUNCEMENT_STORAGE_KEY) === 'true') banner.remove();
   }
 
   function setupInstallPrompt() {
@@ -102,51 +117,31 @@ function initGlobalAnnouncements() {
       deferredInstallPrompt = event;
       document.body.appendChild(pwaBanner);
     });
-
-    const installButton = pwaBanner.querySelector('#pwaInstallButton');
-    const dismissButton = pwaBanner.querySelector('#pwaInstallDismiss');
-
-    installButton.addEventListener('click', async () => {
-      if (!deferredInstallPrompt) {
-        return;
-      }
+    pwaBanner.querySelector('#pwaInstallButton').addEventListener('click', async () => {
+      if (!deferredInstallPrompt) return;
       deferredInstallPrompt.prompt();
       await deferredInstallPrompt.userChoice;
       deferredInstallPrompt = null;
       pwaBanner.remove();
     });
-
-    dismissButton.addEventListener('click', () => {
-      pwaBanner.remove();
-    });
+    pwaBanner.querySelector('#pwaInstallDismiss').addEventListener('click', () => pwaBanner.remove());
   }
 
   function setupServiceWorker() {
-    if (!('serviceWorker' in navigator)) {
-      return;
-    }
-
-    const swSetting = document
-      .querySelector('meta[name="aetheron-sw"]')
-      ?.getAttribute('content');
-
-    if (swSetting === 'off') {
-      return;
-    }
-
+    if (!('serviceWorker' in navigator)) return;
+    const swSetting = document.querySelector('meta[name="aetheron-sw"]')?.getAttribute('content');
+    if (swSetting === 'off') return;
     navigator.serviceWorker.register(serviceWorkerUrl).catch(() => {});
-
     navigator.serviceWorker.addEventListener('message', (event) => {
-      if (event.data && event.data.type === 'CACHE_READY') {
-        if (localStorage.getItem(OFFLINE_TOAST_KEY) !== 'true') {
-          localStorage.setItem(OFFLINE_TOAST_KEY, 'true');
-          showToast('Offline ready. Content cached for fast reloads.');
-        }
+      if (event.data?.type === 'CACHE_READY' && localStorage.getItem(OFFLINE_TOAST_KEY) !== 'true') {
+        localStorage.setItem(OFFLINE_TOAST_KEY, 'true');
+        showToast('Offline ready. Content cached for fast reloads.');
       }
     });
   }
 
   document.addEventListener('DOMContentLoaded', () => {
+    enforceDashboardBranding();
     document.body.prepend(banner);
     document.body.appendChild(toastContainer);
     registerAnnouncementDismiss();


### PR DESCRIPTION
## Fixes
- Forces the existing dashboard navbar to retain its dark glass treatment even when an old saved light-theme preference is present.
- Replaces the visible legacy `Polygon DeFi Command` caption with `Base DeFi Command` through the always-loaded announcement runtime.
- Fixes the malformed `?v=1.4.7dashboard.html` announcement link by parsing the script URL without its query string.

The layout, card structure, typography, and overall dashboard design are unchanged.