### PR TITLE
Align AETH verification with Etherscan V2 documentation

### DIFF
--- a/.github/workflows/verify-aeth-base.yml
+++ b/.github/workflows/verify-aeth-base.yml
@@ -55,7 +55,7 @@ jobs:
         run: npm test
       - name: Verify AETH and capture readback evidence
         working-directory: smart-contract
-        run: node scripts/verify-aeth-basescan-v2.mjs
+        run: node scripts/verify-aeth-basescan-v2-doc-aligned.mjs
       - name: Persist verified deployment record
         run: |
           git config user.name "github-actions[bot]"

--- a/smart-contract/scripts/verify-aeth-basescan-v2-doc-aligned.mjs
+++ b/smart-contract/scripts/verify-aeth-basescan-v2-doc-aligned.mjs
@@ -1,0 +1,28 @@
+// Normalize requests to the methods and parameter casing documented by Etherscan V2,
+// then run the verification implementation.
+const nativeFetch = globalThis.fetch;
+globalThis.fetch = async (input, init = {}) => {
+  const url = new URL(String(input));
+  const body = init.body instanceof URLSearchParams
+    ? new URLSearchParams(init.body)
+    : init.body;
+
+  if (body instanceof URLSearchParams && body.has("evmversion")) {
+    body.set("evmVersion", body.get("evmversion"));
+    body.delete("evmversion");
+  }
+
+  if (url.searchParams.get("action") === "checkverifystatus" && !init.method) {
+    const params = new URLSearchParams(url.searchParams);
+    url.search = "";
+    return nativeFetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: params
+    });
+  }
+
+  return nativeFetch(url, { ...init, body });
+};
+
+await import("./verify-aeth-basescan-v2.mjs");


### PR DESCRIPTION
Uses the complete Etherscan documentation index and aligns the AETH verification workflow with the documented V2 request contract: POST status checks and `evmVersion` parameter casing. All Base verification/readback safeguards remain intact.