### PR TITLE
Fix Base chain ID in verification status polling

### DIFF
--- a/smart-contract/scripts/verify-aeth-basescan-v2-doc-aligned.mjs
+++ b/smart-contract/scripts/verify-aeth-basescan-v2-doc-aligned.mjs
@@ -84,7 +84,8 @@ globalThis.fetch = async (input, init = {}) => {
 
   if (action === "checkverifystatus" && !init.method) {
     const params = new URLSearchParams(url.searchParams);
-    url.search = "";
+    const chainId = params.get("chainid") || "8453";
+    url.search = `?chainid=${encodeURIComponent(chainId)}`;
     return nativeFetch(url, {
       method: "POST",
       headers: { "content-type": "application/x-www-form-urlencoded" },


### PR DESCRIPTION
Retains `chainid=8453` in the Etherscan V2 POST URL while polling the verification GUID. This addresses the exact failure shown by the second workflow run; source compilation and contract tests already passed.