### PR TITLE
Refine AETH token logo with orbital emblem

### DIFF
--- a/aeth-token-logo-32.svg
+++ b/aeth-token-logo-32.svg
@@ -1,17 +1,32 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" role="img" aria-labelledby="title desc">
   <title id="title">Aetheron AETH token</title>
-  <desc id="desc">A cyan and violet Aetheron token mark on a dark background.</desc>
+  <desc id="desc">An orbital cyan and violet Aetheron emblem.</desc>
   <defs>
-    <linearGradient id="bg" x1="3" y1="2" x2="29" y2="30" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#071A2B"/>
-      <stop offset="1" stop-color="#171033"/>
+    <radialGradient id="bg" cx="9" cy="7" r="30" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#12324A"/>
+      <stop offset=".5" stop-color="#091629"/>
+      <stop offset="1" stop-color="#150B2B"/>
+    </radialGradient>
+    <linearGradient id="a" x1="10" y1="8" x2="23" y2="24" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#72F3FF"/>
+      <stop offset=".48" stop-color="#24C8F4"/>
+      <stop offset="1" stop-color="#9B6CFF"/>
     </linearGradient>
-    <linearGradient id="mark" x1="9" y1="7" x2="24" y2="25" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#56E7FF"/>
-      <stop offset="1" stop-color="#8B5CF6"/>
+    <linearGradient id="orbit" x1="5" y1="10" x2="28" y2="22" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6FF3FF" stop-opacity=".15"/>
+      <stop offset=".45" stop-color="#54DFFF"/>
+      <stop offset="1" stop-color="#A56CFF" stop-opacity=".2"/>
     </linearGradient>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation=".55" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
   <rect width="32" height="32" rx="8" fill="url(#bg)"/>
-  <path d="M16 5.5 25 23h-4.6l-1.55-3.25h-5.7L11.6 23H7L16 5.5Zm0 7.15-1.55 3.55h3.1L16 12.65Z" fill="url(#mark)"/>
-  <circle cx="25.5" cy="7" r="1.5" fill="#56E7FF"/>
+  <rect x=".5" y=".5" width="31" height="31" rx="7.5" fill="none" stroke="#70EFFF" stroke-opacity=".18"/>
+  <ellipse cx="16" cy="16" rx="12" ry="5.2" transform="rotate(-18 16 16)" fill="none" stroke="url(#orbit)" stroke-width="1.15"/>
+  <path d="M16 6.4 24 24h-4.15l-1.2-3h-5.3l-1.2 3H8L16 6.4Zm0 7.2-1.35 3.85h2.7L16 13.6Z" fill="url(#a)" filter="url(#glow)"/>
+  <path d="M12.6 18.7h6.8" stroke="#D9FBFF" stroke-width="1" stroke-linecap="round" opacity=".9"/>
+  <circle cx="26.25" cy="12.15" r="1.45" fill="#8D78FF" stroke="#C8F8FF" stroke-width=".45" filter="url(#glow)"/>
+  <circle cx="6.2" cy="19.8" r=".75" fill="#61EDFF"/>
 </svg>


### PR DESCRIPTION
Replaces the generic lettermark with a distinctive orbital Aetheron emblem designed specifically for 32×32 token display. It preserves the stable BaseScan URL and existing cyan/violet brand palette.