### PR TITLE
Adopt cosmic gold AETH token emblem

### DIFF
--- a/aeth-token-logo-32.svg
+++ b/aeth-token-logo-32.svg
@@ -1,32 +1,42 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" role="img" aria-labelledby="title desc">
   <title id="title">Aetheron AETH token</title>
-  <desc id="desc">An orbital cyan and violet Aetheron emblem.</desc>
+  <desc id="desc">A golden celestial Aetheron spire orbiting a blue world.</desc>
   <defs>
-    <radialGradient id="bg" cx="9" cy="7" r="30" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#12324A"/>
-      <stop offset=".5" stop-color="#091629"/>
-      <stop offset="1" stop-color="#150B2B"/>
+    <radialGradient id="space" cx="10" cy="7" r="29" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#182540"/>
+      <stop offset=".55" stop-color="#070B17"/>
+      <stop offset="1" stop-color="#02030A"/>
     </radialGradient>
-    <linearGradient id="a" x1="10" y1="8" x2="23" y2="24" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#72F3FF"/>
-      <stop offset=".48" stop-color="#24C8F4"/>
-      <stop offset="1" stop-color="#9B6CFF"/>
+    <radialGradient id="world" cx="10.5" cy="10.5" r="14" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#B5F5FF"/>
+      <stop offset=".22" stop-color="#38BDF8"/>
+      <stop offset=".58" stop-color="#1659A7"/>
+      <stop offset="1" stop-color="#07152F"/>
+    </radialGradient>
+    <linearGradient id="gold" x1="11" y1="6" x2="22" y2="25" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFF1A6"/>
+      <stop offset=".28" stop-color="#F9C64E"/>
+      <stop offset=".64" stop-color="#B66A10"/>
+      <stop offset="1" stop-color="#FFE17A"/>
     </linearGradient>
-    <linearGradient id="orbit" x1="5" y1="10" x2="28" y2="22" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#6FF3FF" stop-opacity=".15"/>
-      <stop offset=".45" stop-color="#54DFFF"/>
-      <stop offset="1" stop-color="#A56CFF" stop-opacity=".2"/>
-    </linearGradient>
-    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
-      <feGaussianBlur stdDeviation=".55" result="b"/>
+    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation=".65" result="b"/>
       <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
+    <clipPath id="disc"><circle cx="16" cy="16" r="15.5"/></clipPath>
   </defs>
-  <rect width="32" height="32" rx="8" fill="url(#bg)"/>
-  <rect x=".5" y=".5" width="31" height="31" rx="7.5" fill="none" stroke="#70EFFF" stroke-opacity=".18"/>
-  <ellipse cx="16" cy="16" rx="12" ry="5.2" transform="rotate(-18 16 16)" fill="none" stroke="url(#orbit)" stroke-width="1.15"/>
-  <path d="M16 6.4 24 24h-4.15l-1.2-3h-5.3l-1.2 3H8L16 6.4Zm0 7.2-1.35 3.85h2.7L16 13.6Z" fill="url(#a)" filter="url(#glow)"/>
-  <path d="M12.6 18.7h6.8" stroke="#D9FBFF" stroke-width="1" stroke-linecap="round" opacity=".9"/>
-  <circle cx="26.25" cy="12.15" r="1.45" fill="#8D78FF" stroke="#C8F8FF" stroke-width=".45" filter="url(#glow)"/>
-  <circle cx="6.2" cy="19.8" r=".75" fill="#61EDFF"/>
+  <circle cx="16" cy="16" r="15.5" fill="url(#space)" stroke="#C9902F" stroke-width=".7"/>
+  <g clip-path="url(#disc)">
+    <circle cx="16" cy="16.5" r="9.4" fill="url(#world)" stroke="#8AE8FF" stroke-width=".45"/>
+    <path d="M7.8 15.2c3.8-2.1 5.2-1.2 7.1-2.9 2.4-2.2 4.1-1 8.9-.5M8.4 19.6c3.1-1.5 5.4.5 8.1-.9 2.2-1.1 4 .2 7.2 1.4" fill="none" stroke="#D7FAFF" stroke-width=".55" stroke-linecap="round" opacity=".62"/>
+    <circle cx="8" cy="7" r=".45" fill="#FFFFFF"/>
+    <circle cx="25" cy="8.5" r=".35" fill="#8BE9FF"/>
+    <circle cx="6" cy="23.8" r=".3" fill="#FFFFFF"/>
+  </g>
+  <circle cx="16" cy="16" r="12.2" fill="none" stroke="#D99527" stroke-width=".5" stroke-dasharray="1.1 1.35" opacity=".9"/>
+  <ellipse cx="16" cy="16" rx="14" ry="10.6" transform="rotate(-18 16 16)" fill="none" stroke="#F4B942" stroke-width=".48" opacity=".72"/>
+  <path d="M16 4.7 17.55 14l6.05 7.1-6.1-3.35L16 20.6l-1.5-2.85-6.1 3.35 6.05-7.1L16 4.7Z" fill="url(#gold)" stroke="#FFE59A" stroke-width=".32" filter="url(#glow)"/>
+  <path d="M16 20.1 18.15 24.7 16 27.8l-2.15-3.1L16 20.1Z" fill="url(#gold)" stroke="#FFE59A" stroke-width=".28"/>
+  <path d="M16 7.1v10.3" stroke="#FFF4BF" stroke-width=".42" opacity=".7"/>
+  <circle cx="26.6" cy="10.4" r=".85" fill="#F8C34D" stroke="#FFF0A0" stroke-width=".3" filter="url(#glow)"/>
 </svg>


### PR DESCRIPTION
Reworks the BaseScan token logo to echo the supplied presale artwork without copying it: a gold celestial spire, blue world, orbital rings, and deep-space field. The SVG remains exactly 32×32 and keeps the existing production URL.