### PR TITLE
ci: add fresh Slither, Forge, and Hardhat validation

### DIFF
--- a/.github/workflows/contract-security-validation.yml
+++ b/.github/workflows/contract-security-validation.yml
@@ -1,0 +1,71 @@
+name: Contract Security Validation
+
+on:
+  pull_request:
+    paths:
+      - 'smart-contract/**'
+      - '.github/workflows/contract-security-validation.yml'
+  workflow_dispatch:
+  schedule:
+    - cron: '23 8 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  hardhat-validation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: smart-contract
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: smart-contract/package-lock.json
+      - run: npm ci
+      - run: npm run compile
+      - run: npm test
+      - run: npm run test:production-simulation
+
+  slither:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: smart-contract/package-lock.json
+      - name: Install contract dependencies
+        working-directory: smart-contract
+        run: npm ci
+      - name: Install Slither
+        run: pipx install slither-analyzer
+      - name: Run Slither against Hardhat project
+        working-directory: smart-contract
+        run: slither . --compile-force-framework hardhat --exclude-dependencies --fail-pedantic
+
+  forge-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: smart-contract
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: smart-contract/package-lock.json
+      - run: npm ci
+      - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+      - name: Compile Solidity with Forge
+        run: forge build --root . --contracts contracts --lib-paths node_modules

--- a/.github/workflows/contract-security-validation.yml
+++ b/.github/workflows/contract-security-validation.yml
@@ -68,4 +68,4 @@ jobs:
         with:
           version: stable
       - name: Compile Solidity with Forge
-        run: forge build --root . --contracts contracts --lib-paths node_modules
+        run: forge build

--- a/smart-contract/foundry.toml
+++ b/smart-contract/foundry.toml
@@ -1,0 +1,11 @@
+[profile.default]
+src = "contracts"
+test = "test-foundry"
+out = "out"
+libs = ["node_modules"]
+solc_version = "0.8.20"
+optimizer = true
+optimizer_runs = 200
+
+[fmt]
+line_length = 100


### PR DESCRIPTION
Closes #147.

This adds a repeatable smart-contract security gate that:

- installs exact Node dependencies
- compiles with Hardhat
- runs the complete Node contract test suite
- runs the production presale simulation
- runs Slither against the Hardhat project with dependency findings excluded and pedantic failure enabled
- compiles the Solidity tree independently with Forge
- runs on contract PRs, manual dispatch, and a weekly schedule

It also adds `smart-contract/foundry.toml`, aligned to the existing Solidity 0.8.20 optimizer settings and `contracts` source layout.

No deployment keys or write-capable Base operations are used by this workflow.