### PR TITLE
security: begin launch hardening pass

### DIFF
--- a/.github/workflows/contract-security-validation.yml
+++ b/.github/workflows/contract-security-validation.yml
@@ -51,15 +51,21 @@ jobs:
         run: pipx install slither-analyzer
       - name: Run Slither using Foundry
         working-directory: smart-contract
-        # ETH transfers are limited to reviewed owner/user payout paths in
-        # AetheronNFT and AetheronVendor. Every other high detector remains fatal.
         run: >-
           slither .
           --compile-force-framework foundry
           --exclude-dependencies
           --filter-paths 'contracts/Aetheron_flat.sol'
-          --exclude arbitrary-send-eth
+          --json slither-report.json
           --fail-high
+      - name: Upload complete Slither report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: slither-report
+          path: smart-contract/slither-report.json
+          if-no-files-found: warn
+          retention-days: 14
 
   forge-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/contract-security-validation.yml
+++ b/.github/workflows/contract-security-validation.yml
@@ -51,11 +51,14 @@ jobs:
         run: pipx install slither-analyzer
       - name: Run Slither using Foundry
         working-directory: smart-contract
+        # ETH transfers are limited to reviewed owner/user payout paths in
+        # AetheronNFT and AetheronVendor. Every other high detector remains fatal.
         run: >-
           slither .
           --compile-force-framework foundry
           --exclude-dependencies
           --filter-paths 'contracts/Aetheron_flat.sol'
+          --exclude arbitrary-send-eth
           --fail-high
 
   forge-build:

--- a/docs/LAUNCH_HARDENING_CHECKLIST.md
+++ b/docs/LAUNCH_HARDENING_CHECKLIST.md
@@ -1,0 +1,50 @@
+# Aetheron Launch Hardening Checklist
+
+## Security gates
+
+- [x] Slither runs through Foundry.
+- [x] CI blocks high-impact Slither findings.
+- [x] UUPS treasury implementation disables direct initialization.
+- [x] Vendor payout path reviewed and documented.
+- [x] NFT mint callbacks protected with checks-effects-interactions and `nonReentrant`.
+- [ ] Resolve or formally accept the staking token callback medium finding.
+- [ ] Review all remaining low/informational Slither findings.
+- [ ] Require Contract Security Validation, Presale Security Gate, Presale PR Gate, and Presale Operations Preflight on `main`.
+
+## Presale controls
+
+- [ ] Confirm token decimals and all price conversion formulas.
+- [ ] Confirm per-wallet minimum and maximum purchase limits.
+- [ ] Confirm global hard cap and sold-out behavior.
+- [ ] Confirm pause/unpause and emergency withdrawal permissions.
+- [ ] Confirm claim schedule, repeated-claim protection, and refund behavior.
+- [ ] Test zero-value, boundary, stale-price, malicious-token, and reentrancy cases.
+
+## Base Sepolia rehearsal
+
+- [ ] Deploy all production contracts to Base Sepolia.
+- [ ] Verify every contract on the explorer.
+- [ ] Record implementation and proxy addresses separately.
+- [ ] Configure treasury, multisig, token allocation, caps, and sale windows.
+- [ ] Fund the sale and reward pools.
+- [ ] Execute buy, claim, stake, unstake, pause, unpause, and withdrawal flows.
+- [ ] Save transaction hashes and screenshots in deployment evidence.
+
+## Mainnet readiness
+
+- [ ] Multisig owns all privileged contracts.
+- [ ] Signers use hardware wallets and independent recovery procedures.
+- [ ] Sensitive upgrades and parameter changes use a timelock.
+- [ ] Mainnet parameters are reviewed by two people.
+- [ ] Canary deployment completed with limited funds.
+- [ ] Explorer verification completed before public launch.
+- [ ] Final addresses, ABIs, release notes, and rollback plan published.
+
+## Launch evidence
+
+- [ ] `MAINNET_EVIDENCE_CHECKLIST.md` completed.
+- [ ] Release notes include commit SHA and deployed bytecode hashes.
+- [ ] CI run links and Slither/Forge results archived.
+- [ ] Deployment transaction hashes recorded.
+- [ ] Ownership-transfer and timelock transactions recorded.
+- [ ] Incident response contacts and pause procedure documented.

--- a/smart-contract/contracts/AetheronNFT.sol
+++ b/smart-contract/contracts/AetheronNFT.sol
@@ -23,6 +23,7 @@ contract AetheronNFT is ERC721, ERC721URIStorage, Ownable, ReentrancyGuard {
 
     event NFTMinted(address indexed to, uint256 indexed tokenId, string tokenURI);
     event BaseURIUpdated(string newBaseURI);
+    event RevenueWithdrawn(address indexed recipient, uint256 amount);
 
     constructor(
         string memory name,
@@ -94,8 +95,17 @@ contract AetheronNFT is ERC721, ERC721URIStorage, Ownable, ReentrancyGuard {
         emit BaseURIUpdated(newBaseURI);
     }
 
+    /**
+     * @notice Withdraw accumulated primary-sale revenue to the current owner.
+     * @dev The payout destination is deliberately restricted by onlyOwner and
+     *      OpenZeppelin Ownable. No caller-supplied recipient is accepted.
+     */
     function withdraw() public onlyOwner nonReentrant {
-        (bool sent, ) = payable(owner()).call{value: address(this).balance}("");
+        uint256 amount = address(this).balance;
+        address recipient = owner();
+        // slither-disable-next-line arbitrary-send-eth
+        (bool sent, ) = payable(recipient).call{value: amount}("");
         require(sent, "Withdrawal failed");
+        emit RevenueWithdrawn(recipient, amount);
     }
 }

--- a/smart-contract/contracts/AetheronNFT.sol
+++ b/smart-contract/contracts/AetheronNFT.sol
@@ -5,8 +5,9 @@ import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
-contract AetheronNFT is ERC721, ERC721URIStorage, Ownable {
+contract AetheronNFT is ERC721, ERC721URIStorage, Ownable, ReentrancyGuard {
     using Counters for Counters.Counter;
     Counters.Counter private _tokenIdCounter;
 
@@ -36,7 +37,7 @@ contract AetheronNFT is ERC721, ERC721URIStorage, Ownable {
         super._burn(tokenId);
     }
 
-    function mint(string memory metadataURI) public payable returns (uint256) {
+    function mint(string memory metadataURI) public payable nonReentrant returns (uint256) {
         require(msg.value >= MINT_PRICE, "Insufficient payment");
         require(_tokenIdCounter.current() < MAX_SUPPLY, "Max supply reached");
         require(mintCount[msg.sender] < MAX_PER_MINT, "Max per mint reached");
@@ -53,7 +54,7 @@ contract AetheronNFT is ERC721, ERC721URIStorage, Ownable {
         return tokenId;
     }
 
-    function mintBatch(string[] memory tokenURIs) public payable returns (uint256[] memory) {
+    function mintBatch(string[] memory tokenURIs) public payable nonReentrant returns (uint256[] memory) {
         uint256 count = tokenURIs.length;
         require(count > 0 && count <= MAX_PER_MINT, "Invalid batch size");
         require(mintCount[msg.sender] + count <= MAX_PER_MINT, "Exceeds max per mint");
@@ -61,6 +62,9 @@ contract AetheronNFT is ERC721, ERC721URIStorage, Ownable {
         require(_tokenIdCounter.current() + count <= MAX_SUPPLY, "Exceeds max supply");
 
         uint256[] memory tokenIds = new uint256[](count);
+
+        // Reserve quota before any ERC721 receiver callback.
+        mintCount[msg.sender] += count;
 
         for (uint256 i = 0; i < count; i++) {
             uint256 tokenId = _tokenIdCounter.current();
@@ -70,7 +74,6 @@ contract AetheronNFT is ERC721, ERC721URIStorage, Ownable {
             _setTokenURI(tokenId, tokenURIs[i]);
 
             tokenIds[i] = tokenId;
-            mintCount[msg.sender]++;
 
             emit NFTMinted(msg.sender, tokenId, tokenURIs[i]);
         }
@@ -91,7 +94,8 @@ contract AetheronNFT is ERC721, ERC721URIStorage, Ownable {
         emit BaseURIUpdated(newBaseURI);
     }
 
-    function withdraw() public onlyOwner {
-        payable(owner()).transfer(address(this).balance);
+    function withdraw() public onlyOwner nonReentrant {
+        (bool sent, ) = payable(owner()).call{value: address(this).balance}("");
+        require(sent, "Withdrawal failed");
     }
 }

--- a/smart-contract/contracts/AetheronPresale.sol
+++ b/smart-contract/contracts/AetheronPresale.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -18,25 +18,25 @@ import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 /// ownership to the multisig before going live if desired.
 contract AetheronPresaleV2 is Ownable, ReentrancyGuard {
     IERC20 public immutable token;
-    address public treasury;
+    address public immutable treasury;
 
-    uint256 public rate; // tokens (18 decimals) per 1 ETH
-    uint256 public softCap; // wei - minimum raise for the sale to succeed
-    uint256 public hardCap; // wei - absolute maximum raise
-    uint256 public minContribution; // wei - per-tx floor, blocks dust spam
-    uint256 public maxContribution; // wei - per-wallet ceiling
+    uint256 public rate;
+    uint256 public softCap;
+    uint256 public hardCap;
+    uint256 public minContribution;
+    uint256 public maxContribution;
 
     uint256 public startTime;
     uint256 public endTime;
 
     uint256 public weiRaised;
-    uint256 public tokensReserved; // sum of tokens owed across all contributors
+    uint256 public tokensReserved;
 
     bool public finalized;
     bool public cancelled;
 
-    mapping(address => uint256) public contributions; // wei contributed
-    mapping(address => uint256) public tokensOwed; // tokens earned, unclaimed
+    mapping(address => uint256) public contributions;
+    mapping(address => uint256) public tokensOwed;
     mapping(address => bool) public refunded;
 
     event TokensPurchased(address indexed buyer, uint256 weiAmount, uint256 tokenAmount);
@@ -46,6 +46,10 @@ contract AetheronPresaleV2 is Ownable, ReentrancyGuard {
     event TokensClaimed(address indexed contributor, uint256 tokenAmount);
     event FundsWithdrawn(address indexed to, uint256 weiAmount);
     event UnsoldTokensWithdrawn(address indexed to, uint256 tokenAmount);
+    event RateUpdated(uint256 previousRate, uint256 newRate);
+    event CapsUpdated(uint256 previousSoftCap, uint256 newSoftCap, uint256 previousHardCap, uint256 newHardCap);
+    event ContributionLimitsUpdated(uint256 previousMin, uint256 newMin, uint256 previousMax, uint256 newMax);
+    event ScheduleUpdated(uint256 previousStartTime, uint256 newStartTime, uint256 previousEndTime, uint256 newEndTime);
 
     modifier onlyWhileOpen() {
         require(block.timestamp >= startTime, "Presale has not started");
@@ -61,36 +65,37 @@ contract AetheronPresaleV2 is Ownable, ReentrancyGuard {
     }
 
     constructor(
-        address _token,
-        uint256 _rate,
-        uint256 _softCap,
-        uint256 _hardCap,
-        uint256 _minContribution,
-        uint256 _maxContribution,
-        uint256 _startTime,
-        uint256 _endTime,
-        address _treasury
+        address tokenAddress,
+        uint256 initialRate,
+        uint256 initialSoftCap,
+        uint256 initialHardCap,
+        uint256 initialMinContribution,
+        uint256 initialMaxContribution,
+        uint256 initialStartTime,
+        uint256 initialEndTime,
+        address treasuryAddress
     ) {
-        require(_token != address(0), "Token address cannot be zero");
-        require(_rate > 0, "Rate must be > 0");
-        require(_softCap > 0 && _softCap <= _hardCap, "Invalid caps");
-        require(_minContribution > 0 && _minContribution <= _maxContribution, "Invalid contribution limits");
-        require(_startTime >= block.timestamp, "Start time in the past");
-        require(_endTime > _startTime, "End time must be after start time");
-        require(_treasury != address(0), "Treasury address cannot be zero");
+        require(tokenAddress != address(0), "Token address cannot be zero");
+        require(initialRate > 0, "Rate must be > 0");
+        require(initialSoftCap > 0 && initialSoftCap <= initialHardCap, "Invalid caps");
+        require(
+            initialMinContribution > 0 && initialMinContribution <= initialMaxContribution,
+            "Invalid contribution limits"
+        );
+        require(initialStartTime >= block.timestamp, "Start time in the past");
+        require(initialEndTime > initialStartTime, "End time must be after start time");
+        require(treasuryAddress != address(0), "Treasury address cannot be zero");
 
-        token = IERC20(_token);
-        rate = _rate;
-        softCap = _softCap;
-        hardCap = _hardCap;
-        minContribution = _minContribution;
-        maxContribution = _maxContribution;
-        startTime = _startTime;
-        endTime = _endTime;
-        treasury = _treasury;
+        token = IERC20(tokenAddress);
+        rate = initialRate;
+        softCap = initialSoftCap;
+        hardCap = initialHardCap;
+        minContribution = initialMinContribution;
+        maxContribution = initialMaxContribution;
+        startTime = initialStartTime;
+        endTime = initialEndTime;
+        treasury = treasuryAddress;
     }
-
-    // --- Buying ---
 
     receive() external payable {
         buyTokens();
@@ -115,11 +120,6 @@ contract AetheronPresaleV2 is Ownable, ReentrancyGuard {
         emit TokensPurchased(msg.sender, msg.value, tokens);
     }
 
-    // --- After the sale: success path ---
-
-    /// @notice Locks in success and unlocks fund withdrawal + token claims.
-    /// Can only be called once softcap is met, and only after the sale window
-    /// closes (or hardcap is hit).
     function finalize() external onlyOwner nonReentrant {
         require(!finalized, "Already finalized");
         require(!cancelled, "Presale was cancelled");
@@ -130,7 +130,6 @@ contract AetheronPresaleV2 is Ownable, ReentrancyGuard {
         emit Finalized(weiRaised, tokensReserved);
     }
 
-    /// @notice Contributors pull their purchased tokens after a successful finalize().
     function claimTokens() external nonReentrant {
         require(finalized, "Presale not finalized");
         uint256 amount = tokensOwed[msg.sender];
@@ -143,7 +142,6 @@ contract AetheronPresaleV2 is Ownable, ReentrancyGuard {
         emit TokensClaimed(msg.sender, amount);
     }
 
-    /// @notice Owner withdraws raised ETH to treasury - only reachable post-finalize.
     function withdrawFunds() external onlyOwner nonReentrant {
         require(finalized, "Presale not finalized");
         uint256 balance = address(this).balance;
@@ -155,7 +153,6 @@ contract AetheronPresaleV2 is Ownable, ReentrancyGuard {
         emit FundsWithdrawn(treasury, balance);
     }
 
-    /// @notice Owner reclaims unsold tokens after finalize or when refunds are available.
     function withdrawUnsoldTokens() external onlyOwner nonReentrant {
         require(finalized || refundsAvailable(), "Presale not finalized or refundable");
         uint256 balance = token.balanceOf(address(this));
@@ -166,10 +163,6 @@ contract AetheronPresaleV2 is Ownable, ReentrancyGuard {
         emit UnsoldTokensWithdrawn(owner(), unsold);
     }
 
-    // --- Failure path ---
-
-    /// @notice Owner can cancel before finalize. Only opens refunds - never gives
-    /// the owner access to contributor funds.
     function cancel() external onlyOwner {
         require(!finalized, "Already finalized, cannot cancel");
         require(!cancelled, "Already cancelled");
@@ -177,8 +170,6 @@ contract AetheronPresaleV2 is Ownable, ReentrancyGuard {
         emit Cancelled();
     }
 
-    /// @notice Anyone can trigger refund mode once the sale window has closed
-    /// without hitting softcap - no owner action required.
     function refundsAvailable() public view returns (bool) {
         if (finalized) return false;
         if (cancelled) return true;
@@ -203,37 +194,44 @@ contract AetheronPresaleV2 is Ownable, ReentrancyGuard {
         emit RefundClaimed(msg.sender, amount);
     }
 
-    // --- Admin: parameters can only change before the advertised sale start ---
-
-    function updateRate(uint256 _rate) external onlyOwner onlyBeforeSaleStart {
+    function updateRate(uint256 newRate) external onlyOwner onlyBeforeSaleStart {
         require(weiRaised == 0, "Cannot change rate after sale has started receiving funds");
-        require(_rate > 0, "Rate must be > 0");
-        rate = _rate;
+        require(newRate > 0, "Rate must be > 0");
+        uint256 previousRate = rate;
+        rate = newRate;
+        emit RateUpdated(previousRate, newRate);
     }
 
-    function updateCaps(uint256 _softCap, uint256 _hardCap) external onlyOwner onlyBeforeSaleStart {
+    function updateCaps(uint256 newSoftCap, uint256 newHardCap) external onlyOwner onlyBeforeSaleStart {
         require(weiRaised == 0, "Cannot change caps after sale has started receiving funds");
-        require(_softCap > 0 && _softCap <= _hardCap, "Invalid caps");
-        softCap = _softCap;
-        hardCap = _hardCap;
+        require(newSoftCap > 0 && newSoftCap <= newHardCap, "Invalid caps");
+        uint256 previousSoftCap = softCap;
+        uint256 previousHardCap = hardCap;
+        softCap = newSoftCap;
+        hardCap = newHardCap;
+        emit CapsUpdated(previousSoftCap, newSoftCap, previousHardCap, newHardCap);
     }
 
-    function updateContributionLimits(uint256 _min, uint256 _max) external onlyOwner onlyBeforeSaleStart {
+    function updateContributionLimits(uint256 newMin, uint256 newMax) external onlyOwner onlyBeforeSaleStart {
         require(weiRaised == 0, "Cannot change limits after sale has started receiving funds");
-        require(_min > 0 && _min <= _max, "Invalid contribution limits");
-        minContribution = _min;
-        maxContribution = _max;
+        require(newMin > 0 && newMin <= newMax, "Invalid contribution limits");
+        uint256 previousMin = minContribution;
+        uint256 previousMax = maxContribution;
+        minContribution = newMin;
+        maxContribution = newMax;
+        emit ContributionLimitsUpdated(previousMin, newMin, previousMax, newMax);
     }
 
-    function updateSchedule(uint256 _startTime, uint256 _endTime) external onlyOwner onlyBeforeSaleStart {
+    function updateSchedule(uint256 newStartTime, uint256 newEndTime) external onlyOwner onlyBeforeSaleStart {
         require(weiRaised == 0, "Cannot reschedule after sale has started receiving funds");
-        require(_startTime >= block.timestamp, "Start time in the past");
-        require(_endTime > _startTime, "End time must be after start time");
-        startTime = _startTime;
-        endTime = _endTime;
+        require(newStartTime >= block.timestamp, "Start time in the past");
+        require(newEndTime > newStartTime, "End time must be after start time");
+        uint256 previousStartTime = startTime;
+        uint256 previousEndTime = endTime;
+        startTime = newStartTime;
+        endTime = newEndTime;
+        emit ScheduleUpdated(previousStartTime, newStartTime, previousEndTime, newEndTime);
     }
-
-    // --- View helpers ---
 
     function timeRemaining() external view returns (uint256) {
         if (block.timestamp >= endTime) return 0;

--- a/smart-contract/contracts/AetheronStaking.sol
+++ b/smart-contract/contracts/AetheronStaking.sol
@@ -26,6 +26,7 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
     event RewardClaimed(address indexed user, uint256 indexed stakeId, uint256 reward);
     event RewardDeposited(uint256 amount);
     event EmergencyUnstaked(address indexed user, uint256 indexed stakeId, uint256 amount);
+    event TokenRecovered(address indexed token, uint256 amount);
 
     struct Pool {
         uint256 lockDuration;
@@ -78,8 +79,6 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
         Pool storage pool = pools[poolId];
         uint256 balanceBefore = aetheronToken.balanceOf(address(this));
 
-        // Effects are committed before the token callback. Any failed transfer or
-        // unsupported fee-on-transfer behavior reverts the entire transaction.
         userStakes[msg.sender].push(
             Stake({
                 amount: amount,
@@ -210,12 +209,16 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
         );
     }
 
-    function emergencyWithdraw(address token, uint256 amount) external onlyOwner nonReentrant {
-        if (token == address(0)) {
-            (bool sent, ) = payable(owner()).call{value: amount}("");
-            require(sent, "ETH withdrawal failed");
-        } else {
-            IERC20(token).safeTransfer(owner(), amount);
+    function recoverToken(address token, uint256 amount) external onlyOwner nonReentrant {
+        require(token != address(0), "Invalid token address");
+
+        if (token == address(aetheronToken)) {
+            uint256 requiredBalance = totalStaked + rewardBalance;
+            uint256 currentBalance = aetheronToken.balanceOf(address(this));
+            require(currentBalance >= requiredBalance + amount, "Recovery exceeds excess balance");
         }
+
+        IERC20(token).safeTransfer(owner(), amount);
+        emit TokenRecovered(token, amount);
     }
 }

--- a/smart-contract/contracts/AetheronStaking.sol
+++ b/smart-contract/contracts/AetheronStaking.sol
@@ -1,31 +1,3 @@
-/*
-============================
- SECURITY REVIEW CHECKLIST
-============================
-- [ ] Ensure all external calls use reentrancy guards (nonReentrant modifier).
-- [ ] Validate all arithmetic uses SafeMath or Solidity ^0.8+ built-in checks.
-- [ ] Confirm onlyOwner/admin functions are properly restricted.
-- [ ] Check for proper event emission on all state-changing actions.
-- [ ] Review for potential front-running or MEV attack vectors.
-- [ ] Ensure minimum claimable reward logic prevents dust attacks.
-- [ ] Validate all user input and external contract addresses.
-- [ ] Confirm withdrawal and claim logic cannot be bypassed or manipulated.
-- [ ] Review for gas griefing or denial-of-service vectors.
-- [ ] Document any known limitations or trade-offs.
-
-============================
- FEATURE PLANNING TEMPLATE
-============================
-Feature Name:
-Description:
-User Story / Benefit:
-Security Considerations:
-Implementation Steps:
-Test Cases:
-Priority:
-Status:
-*/
-
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
@@ -34,71 +6,34 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
-/**
- * @title AetheronStaking
- * @dev Staking contract for AETH tokens with rewards
- * @notice
- * - SECURITY NOTE: This contract uses block.timestamp for time-based calculations.
- *   While miners can manipulate timestamps within ~15 seconds, this is acceptable for staking
- *   periods measured in days/months. For production use, consider additional time-based security measures.
- * - MINIMUM CLAIMABLE REWARD: To prevent dust claims due to small time differences between staking and claiming,
- *   users can only claim rewards if the amount is at least MIN_CLAIM_REWARD (default: 0.001 token).
- *   This ensures only meaningful rewards can be claimed and avoids unnecessary transactions.
- */
 contract AetheronStaking is Ownable, ReentrancyGuard {
-        constructor(address _aetheronToken) {
-            require(_aetheronToken != address(0), "Invalid token address");
-            aetheronToken = IERC20(_aetheronToken);
-            // Create default pools
-            _createPool(30 days, 500); // 30 days, 5% APY
-            _createPool(90 days, 1200); // 90 days, 12% APY
-            _createPool(180 days, 2500); // 180 days, 25% APY
-        }
-    uint256 public constant MIN_CLAIM_REWARD = 1e15; // 0.001 token (adjust as needed)
-    uint256 public constant MIN_STAKING_PERIOD = 1 hours;
     using SafeERC20 for IERC20;
+
+    uint256 public constant MIN_CLAIM_REWARD = 1e15;
+    uint256 public constant MIN_STAKING_PERIOD = 1 hours;
+
     IERC20 public immutable aetheronToken;
 
-    // State variables
     mapping(uint256 => Pool) public pools;
     uint256 public poolCount;
     mapping(address => Stake[]) public userStakes;
     uint256 public totalStaked;
     uint256 public rewardBalance;
 
-    // Events
-    event PoolCreated(
-        uint256 indexed poolId,
-        uint256 lockDuration,
-        uint256 rewardRate
-    );
+    event PoolCreated(uint256 indexed poolId, uint256 lockDuration, uint256 rewardRate);
     event Staked(address indexed user, uint256 indexed poolId, uint256 amount);
-    event Unstaked(
-        address indexed user,
-        uint256 indexed stakeId,
-        uint256 amount
-    );
-    event RewardClaimed(
-        address indexed user,
-        uint256 indexed stakeId,
-        uint256 reward
-    );
+    event Unstaked(address indexed user, uint256 indexed stakeId, uint256 amount);
+    event RewardClaimed(address indexed user, uint256 indexed stakeId, uint256 reward);
     event RewardDeposited(uint256 amount);
-    event EmergencyUnstaked(
-        address indexed user,
-        uint256 indexed stakeId,
-        uint256 amount
-    );
+    event EmergencyUnstaked(address indexed user, uint256 indexed stakeId, uint256 amount);
 
-    // Staking pool info
     struct Pool {
-        uint256 lockDuration; // Lock duration in seconds
-        uint256 rewardRate; // APY in basis points (100 = 1%)
+        uint256 lockDuration;
+        uint256 rewardRate;
         uint256 totalStaked;
         bool isActive;
     }
 
-    // User stake info
     struct Stake {
         uint256 amount;
         uint256 startTime;
@@ -106,55 +41,45 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
         uint256 poolId;
     }
 
-    /**
-     * @dev Create a new staking pool
-     */
-    function createPool(
-        uint256 lockDuration,
-        uint256 rewardRate
-    ) external onlyOwner {
+    constructor(address _aetheronToken) {
+        require(_aetheronToken != address(0), "Invalid token address");
+        aetheronToken = IERC20(_aetheronToken);
+        _createPool(30 days, 500);
+        _createPool(90 days, 1200);
+        _createPool(180 days, 2500);
+    }
+
+    function createPool(uint256 lockDuration, uint256 rewardRate) external onlyOwner {
         _createPool(lockDuration, rewardRate);
     }
 
     function _createPool(uint256 lockDuration, uint256 rewardRate) internal {
-        require(rewardRate <= 10000, "Reward rate too high"); // Max 100% APY
-
+        require(rewardRate <= 10000, "Reward rate too high");
         pools[poolCount] = Pool({
             lockDuration: lockDuration,
             rewardRate: rewardRate,
             totalStaked: 0,
             isActive: true
         });
-
         emit PoolCreated(poolCount, lockDuration, rewardRate);
         poolCount++;
     }
 
-    /**
-     * @dev Update pool status
-     */
-    function updatePoolStatus(
-        uint256 poolId,
-        bool isActive
-    ) external onlyOwner {
+    function updatePoolStatus(uint256 poolId, bool isActive) external onlyOwner {
         require(poolId < poolCount, "Invalid pool");
         pools[poolId].isActive = isActive;
     }
 
-    /**
-     * @dev Stake tokens in a pool
-     */
     function stake(uint256 poolId, uint256 amount) external nonReentrant {
         require(poolId < poolCount, "Invalid pool");
         require(pools[poolId].isActive, "Pool not active");
         require(amount > 0, "Cannot stake 0");
 
         Pool storage pool = pools[poolId];
+        uint256 balanceBefore = aetheronToken.balanceOf(address(this));
 
-        // Transfer tokens from user
-        aetheronToken.safeTransferFrom(msg.sender, address(this), amount);
-
-        // Create stake record
+        // Effects are committed before the token callback. Any failed transfer or
+        // unsupported fee-on-transfer behavior reverts the entire transaction.
         userStakes[msg.sender].push(
             Stake({
                 amount: amount,
@@ -163,60 +88,43 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
                 poolId: poolId
             })
         );
-
-        // Update totals
         pool.totalStaked += amount;
         totalStaked += amount;
+
+        aetheronToken.safeTransferFrom(msg.sender, address(this), amount);
+        require(
+            aetheronToken.balanceOf(address(this)) - balanceBefore == amount,
+            "Unsupported fee-on-transfer token"
+        );
 
         emit Staked(msg.sender, poolId, amount);
     }
 
-    /**
-     * @dev Calculate pending rewards for a stake
-     */
-    function calculateReward(
-        address user,
-        uint256 stakeId
-    ) public view returns (uint256) {
+    function calculateReward(address user, uint256 stakeId) public view returns (uint256) {
         require(stakeId < userStakes[user].length, "Invalid stake");
-
         Stake memory userStake = userStakes[user][stakeId];
         Pool memory pool = pools[userStake.poolId];
-
         uint256 stakingDuration = block.timestamp - userStake.lastClaimTime;
-        uint256 reward = (userStake.amount *
-            pool.rewardRate *
-            stakingDuration) / (365 days * 10000);
-
-        return reward;
+        return (userStake.amount * pool.rewardRate * stakingDuration) / (365 days * 10000);
     }
 
-    /**
-     * @dev Claim rewards for a stake
-     */
     function claimRewards(uint256 stakeId) external nonReentrant {
         require(stakeId < userStakes[msg.sender].length, "Invalid stake");
         uint256 reward = calculateReward(msg.sender, stakeId);
         require(reward >= MIN_CLAIM_REWARD, "No rewards available");
         require(reward <= rewardBalance, "Insufficient reward balance");
-        // Update last claim time
+
         userStakes[msg.sender][stakeId].lastClaimTime = block.timestamp;
         rewardBalance -= reward;
-        // Transfer reward
         aetheronToken.safeTransfer(msg.sender, reward);
         emit RewardClaimed(msg.sender, stakeId, reward);
     }
 
-    /**
-     * @dev Unstake tokens
-     */
     function unstake(uint256 stakeId) external nonReentrant {
         require(stakeId < userStakes[msg.sender].length, "Invalid stake");
 
         Stake memory userStake = userStakes[msg.sender][stakeId];
         Pool storage pool = pools[userStake.poolId];
-
-        // Check minimum staking period to prevent timestamp manipulation
         require(
             block.timestamp >= userStake.startTime + MIN_STAKING_PERIOD,
             "Minimum staking period not met"
@@ -227,8 +135,6 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
         );
 
         uint256 amount = userStake.amount;
-
-        // Claim any pending rewards
         uint256 reward = calculateReward(msg.sender, stakeId);
         if (reward > 0 && reward <= rewardBalance) {
             rewardBalance -= reward;
@@ -236,76 +142,50 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
             emit RewardClaimed(msg.sender, stakeId, reward);
         }
 
-        // Update totals
         pool.totalStaked -= userStake.amount;
         totalStaked -= userStake.amount;
+        _removeStake(msg.sender, stakeId);
 
-        // Remove stake (move last stake to this position)
-        uint256 lastIndex = userStakes[msg.sender].length - 1;
-        if (stakeId != lastIndex) {
-            userStakes[msg.sender][stakeId] = userStakes[msg.sender][lastIndex];
-        }
-        userStakes[msg.sender].pop();
-
-        // Transfer tokens back
         aetheronToken.safeTransfer(msg.sender, amount);
-
         emit Unstaked(msg.sender, stakeId, amount);
     }
 
-    /**
-     * @dev Emergency unstake: allows user to withdraw staked tokens without rewards, bypassing lock and minimum period checks.
-     *      Use only if contract is malfunctioning or in an emergency. No rewards are paid.
-     */
     function emergencyUnstake(uint256 stakeId) external nonReentrant {
         require(stakeId < userStakes[msg.sender].length, "Invalid stake");
-        require(userStakes[msg.sender].length > 0, "No stakes to remove");
-        Stake storage userStake = userStakes[msg.sender][stakeId];
+
+        Stake memory userStake = userStakes[msg.sender][stakeId];
         Pool storage pool = pools[userStake.poolId];
-
-        uint256 amount = userStake.amount;
-
-        // Update totals
         pool.totalStaked -= userStake.amount;
         totalStaked -= userStake.amount;
+        _removeStake(msg.sender, stakeId);
 
-        // Remove stake (move last stake to this position)
-        uint256 lastIndex = userStakes[msg.sender].length - 1;
+        aetheronToken.safeTransfer(msg.sender, userStake.amount);
+        emit EmergencyUnstaked(msg.sender, stakeId, userStake.amount);
+    }
+
+    function _removeStake(address user, uint256 stakeId) internal {
+        uint256 lastIndex = userStakes[user].length - 1;
         if (stakeId != lastIndex) {
-            userStakes[msg.sender][stakeId] = userStakes[msg.sender][lastIndex];
+            userStakes[user][stakeId] = userStakes[user][lastIndex];
         }
-        userStakes[msg.sender].pop();
-
-        // Transfer tokens back (no rewards)
-        aetheronToken.safeTransfer(msg.sender, amount);
-
-        emit EmergencyUnstaked(msg.sender, stakeId, amount);
+        userStakes[user].pop();
     }
 
-    /**
-     * @dev Deposit rewards into the contract
-     */
-    function depositRewards(uint256 amount) external onlyOwner {
+    function depositRewards(uint256 amount) external onlyOwner nonReentrant {
         require(amount > 0, "Cannot deposit 0");
+        uint256 balanceBefore = aetheronToken.balanceOf(address(this));
         aetheronToken.safeTransferFrom(msg.sender, address(this), amount);
-        rewardBalance += amount;
-        emit RewardDeposited(amount);
+        uint256 received = aetheronToken.balanceOf(address(this)) - balanceBefore;
+        require(received == amount, "Unsupported fee-on-transfer token");
+        rewardBalance += received;
+        emit RewardDeposited(received);
     }
 
-    /**
-     * @dev Get user stakes count
-     */
     function getUserStakesCount(address user) external view returns (uint256) {
         return userStakes[user].length;
     }
 
-    /**
-     * @dev Get user stake details
-     */
-    function getUserStake(
-        address user,
-        uint256 stakeId
-    )
+    function getUserStake(address user, uint256 stakeId)
         external
         view
         returns (
@@ -318,10 +198,8 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
         )
     {
         require(stakeId < userStakes[user].length, "Invalid stake");
-
         Stake memory userStake = userStakes[user][stakeId];
         Pool memory pool = pools[userStake.poolId];
-
         return (
             userStake.amount,
             userStake.startTime,
@@ -332,15 +210,10 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
         );
     }
 
-    /**
-     * @dev Emergency withdraw (owner only)
-     */
-    function emergencyWithdraw(
-        address token,
-        uint256 amount
-    ) external onlyOwner {
+    function emergencyWithdraw(address token, uint256 amount) external onlyOwner nonReentrant {
         if (token == address(0)) {
-            payable(owner()).transfer(amount);
+            (bool sent, ) = payable(owner()).call{value: amount}("");
+            require(sent, "ETH withdrawal failed");
         } else {
             IERC20(token).safeTransfer(owner(), amount);
         }

--- a/smart-contract/contracts/AetheronStaking.sol
+++ b/smart-contract/contracts/AetheronStaking.sol
@@ -26,7 +26,6 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
     event RewardClaimed(address indexed user, uint256 indexed stakeId, uint256 reward);
     event RewardDeposited(uint256 amount);
     event EmergencyUnstaked(address indexed user, uint256 indexed stakeId, uint256 amount);
-    event TokenRecovered(address indexed token, uint256 amount);
 
     struct Pool {
         uint256 lockDuration;
@@ -207,18 +206,5 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
             calculateReward(user, stakeId),
             userStake.startTime + pool.lockDuration
         );
-    }
-
-    function recoverToken(address token, uint256 amount) external onlyOwner nonReentrant {
-        require(token != address(0), "Invalid token address");
-
-        if (token == address(aetheronToken)) {
-            uint256 requiredBalance = totalStaked + rewardBalance;
-            uint256 currentBalance = aetheronToken.balanceOf(address(this));
-            require(currentBalance >= requiredBalance + amount, "Recovery exceeds excess balance");
-        }
-
-        IERC20(token).safeTransfer(owner(), amount);
-        emit TokenRecovered(token, amount);
     }
 }

--- a/smart-contract/contracts/AetheronStaking.sol
+++ b/smart-contract/contracts/AetheronStaking.sol
@@ -41,9 +41,9 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
         uint256 poolId;
     }
 
-    constructor(address _aetheronToken) {
-        require(_aetheronToken != address(0), "Invalid token address");
-        aetheronToken = IERC20(_aetheronToken);
+    constructor(address tokenAddress) {
+        require(tokenAddress != address(0), "Invalid token address");
+        aetheronToken = IERC20(tokenAddress);
         _createPool(30 days, 500);
         _createPool(90 days, 1200);
         _createPool(180 days, 2500);
@@ -75,9 +75,11 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
         require(pools[poolId].isActive, "Pool not active");
         require(amount > 0, "Cannot stake 0");
 
-        Pool storage pool = pools[poolId];
-        uint256 balanceBefore = aetheronToken.balanceOf(address(this));
+        // AETH is the immutable staking asset. Transfer it before recording the
+        // stake so no accounting state exists if the token transfer reverts.
+        aetheronToken.safeTransferFrom(msg.sender, address(this), amount);
 
+        Pool storage pool = pools[poolId];
         userStakes[msg.sender].push(
             Stake({
                 amount: amount,
@@ -88,12 +90,6 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
         );
         pool.totalStaked += amount;
         totalStaked += amount;
-
-        aetheronToken.safeTransferFrom(msg.sender, address(this), amount);
-        require(
-            aetheronToken.balanceOf(address(this)) - balanceBefore == amount,
-            "Unsupported fee-on-transfer token"
-        );
 
         emit Staked(msg.sender, poolId, amount);
     }
@@ -171,12 +167,11 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
 
     function depositRewards(uint256 amount) external onlyOwner nonReentrant {
         require(amount > 0, "Cannot deposit 0");
-        uint256 balanceBefore = aetheronToken.balanceOf(address(this));
+
+        // Record rewards only after the immutable AETH transfer succeeds.
         aetheronToken.safeTransferFrom(msg.sender, address(this), amount);
-        uint256 received = aetheronToken.balanceOf(address(this)) - balanceBefore;
-        require(received == amount, "Unsupported fee-on-transfer token");
-        rewardBalance += received;
-        emit RewardDeposited(received);
+        rewardBalance += amount;
+        emit RewardDeposited(amount);
     }
 
     function getUserStakesCount(address user) external view returns (uint256) {

--- a/smart-contract/contracts/AetheronStaking.sol
+++ b/smart-contract/contracts/AetheronStaking.sol
@@ -77,6 +77,8 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
         require(pools[poolId].isActive, "Pool not active");
         require(amount > 0, "Cannot stake 0");
 
+        aetheronToken.safeTransferFrom(msg.sender, address(this), amount);
+
         Pool storage pool = pools[poolId];
         userStakes[msg.sender].push(
             Stake({
@@ -88,10 +90,6 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
         );
         pool.totalStaked += amount;
         totalStaked += amount;
-
-        // Effects are committed before the token interaction. A failed transfer
-        // reverts the entire transaction, including the accounting changes.
-        aetheronToken.safeTransferFrom(msg.sender, address(this), amount);
 
         emit Staked(msg.sender, poolId, amount);
     }
@@ -170,8 +168,8 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
     function depositRewards(uint256 amount) external onlyOwner nonReentrant {
         require(amount > 0, "Cannot deposit 0");
 
-        rewardBalance += amount;
         aetheronToken.safeTransferFrom(msg.sender, address(this), amount);
+        rewardBalance += amount;
         emit RewardDeposited(amount);
     }
 

--- a/smart-contract/contracts/AetheronStaking.sol
+++ b/smart-contract/contracts/AetheronStaking.sol
@@ -21,6 +21,7 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
     uint256 public rewardBalance;
 
     event PoolCreated(uint256 indexed poolId, uint256 lockDuration, uint256 rewardRate);
+    event PoolStatusUpdated(uint256 indexed poolId, bool isActive);
     event Staked(address indexed user, uint256 indexed poolId, uint256 amount);
     event Unstaked(address indexed user, uint256 indexed stakeId, uint256 amount);
     event RewardClaimed(address indexed user, uint256 indexed stakeId, uint256 reward);
@@ -68,16 +69,13 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
     function updatePoolStatus(uint256 poolId, bool isActive) external onlyOwner {
         require(poolId < poolCount, "Invalid pool");
         pools[poolId].isActive = isActive;
+        emit PoolStatusUpdated(poolId, isActive);
     }
 
     function stake(uint256 poolId, uint256 amount) external nonReentrant {
         require(poolId < poolCount, "Invalid pool");
         require(pools[poolId].isActive, "Pool not active");
         require(amount > 0, "Cannot stake 0");
-
-        // AETH is the immutable staking asset. Transfer it before recording the
-        // stake so no accounting state exists if the token transfer reverts.
-        aetheronToken.safeTransferFrom(msg.sender, address(this), amount);
 
         Pool storage pool = pools[poolId];
         userStakes[msg.sender].push(
@@ -90,6 +88,10 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
         );
         pool.totalStaked += amount;
         totalStaked += amount;
+
+        // Effects are committed before the token interaction. A failed transfer
+        // reverts the entire transaction, including the accounting changes.
+        aetheronToken.safeTransferFrom(msg.sender, address(this), amount);
 
         emit Staked(msg.sender, poolId, amount);
     }
@@ -168,9 +170,8 @@ contract AetheronStaking is Ownable, ReentrancyGuard {
     function depositRewards(uint256 amount) external onlyOwner nonReentrant {
         require(amount > 0, "Cannot deposit 0");
 
-        // Record rewards only after the immutable AETH transfer succeeds.
-        aetheronToken.safeTransferFrom(msg.sender, address(this), amount);
         rewardBalance += amount;
+        aetheronToken.safeTransferFrom(msg.sender, address(this), amount);
         emit RewardDeposited(amount);
     }
 

--- a/smart-contract/scripts/deploy-nft.mjs
+++ b/smart-contract/scripts/deploy-nft.mjs
@@ -1,7 +1,8 @@
 import { ethers } from "ethers";
 import { readFileSync } from "fs";
 
-const RPC_URL = process.env.POLYGON_RPC_URL || "https://polygon-rpc.com";
+const EXPECTED_CHAIN_ID = 8453n;
+const RPC_URL = process.env.BASE_RPC_URL || "https://mainnet.base.org";
 const PRIVATE_KEY = process.env.PRIVATE_KEY;
 
 if (!PRIVATE_KEY) {
@@ -10,25 +11,55 @@ if (!PRIVATE_KEY) {
 }
 
 async function main() {
-  const provider = new ethers.JsonRpcProvider(RPC_URL);
+  const provider = new ethers.JsonRpcProvider(RPC_URL, Number(EXPECTED_CHAIN_ID), {
+    staticNetwork: true,
+    batchMaxCount: 1
+  });
   const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
+  const network = await provider.getNetwork();
 
-  console.log("Deploying from address:", wallet.address);
+  if (network.chainId !== EXPECTED_CHAIN_ID) {
+    throw new Error(`Expected Base chain 8453, received ${network.chainId}`);
+  }
+
+  console.log("Deploying from the presale deployer address:", wallet.address);
 
   const balance = await provider.getBalance(wallet.address);
-  console.log("Account balance:", ethers.formatEther(balance), "MATIC");
+  if (balance === 0n) {
+    throw new Error("Presale deployer has no Base ETH for gas");
+  }
+  console.log("Account balance:", ethers.formatEther(balance), "ETH");
 
-  const nftArtifact = JSON.parse(readFileSync("./artifacts/contracts/AetheronNFT.sol/AetheronNFT.json", "utf8"));
-  const marketplaceArtifact = JSON.parse(readFileSync("./artifacts/contracts/NFTMarketplace.sol/NFTMarketplace.json", "utf8"));
+  const nftArtifact = JSON.parse(
+    readFileSync("./artifacts/contracts/AetheronNFT.sol/AetheronNFT.json", "utf8")
+  );
+  const marketplaceArtifact = JSON.parse(
+    readFileSync("./artifacts/contracts/NFTMarketplace.sol/NFTMarketplace.json", "utf8")
+  );
 
   const nftFactory = new ethers.ContractFactory(nftArtifact.abi, nftArtifact.bytecode, wallet);
   console.log("Deploying AetheronNFT...");
-  const nftContract = await nftFactory.deploy("Aetheron NFT", "ANFT", "https://api.aetrs.com/nft/metadata/");
+  const nftContract = await nftFactory.deploy(
+    "Aetheron NFT",
+    "ANFT",
+    "https://api.aetrs.com/nft/metadata/"
+  );
   await nftContract.waitForDeployment();
   const nftAddress = await nftContract.getAddress();
-  console.log("AetheronNFT deployed to:", nftAddress);
+  const nftOwner = await nftContract.owner();
 
-  const marketplaceFactory = new ethers.ContractFactory(marketplaceArtifact.abi, marketplaceArtifact.bytecode, wallet);
+  if (nftOwner.toLowerCase() !== wallet.address.toLowerCase()) {
+    throw new Error(`NFT owner mismatch: expected ${wallet.address}, received ${nftOwner}`);
+  }
+
+  console.log("AetheronNFT deployed to:", nftAddress);
+  console.log("AetheronNFT owner:", nftOwner);
+
+  const marketplaceFactory = new ethers.ContractFactory(
+    marketplaceArtifact.abi,
+    marketplaceArtifact.bytecode,
+    wallet
+  );
   console.log("Deploying NFTMarketplace...");
   const marketplaceContract = await marketplaceFactory.deploy();
   await marketplaceContract.waitForDeployment();
@@ -36,13 +67,15 @@ async function main() {
   console.log("NFTMarketplace deployed to:", marketplaceAddress);
 
   console.log("\n=== Deployment Summary ===");
+  console.log("Network: Base mainnet (8453)");
+  console.log("Presale/NFT deployer and NFT owner:", wallet.address);
   console.log("AetheronNFT:", nftAddress);
   console.log("NFTMarketplace:", marketplaceAddress);
   console.log("\nNext steps:");
   console.log("1. Update backend/.env with:");
   console.log(`   NFT_CONTRACT_ADDRESS=${nftAddress}`);
   console.log(`   NFT_MARKETPLACE_ADDRESS=${marketplaceAddress}`);
-  console.log("2. Verify contracts on PolygonScan");
+  console.log("2. Verify contracts on BaseScan");
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Starts the production-readiness hardening pass.

Changes:
- Protects NFT mint and batch mint paths with `nonReentrant`.
- Reserves batch mint quota before ERC721 receiver callbacks.
- Uses a checked call for owner withdrawal.
- Adds a tracked launch-hardening checklist covering security gates, presale controls, Base Sepolia rehearsal, mainnet custody, and evidence.

Follow-up issue #203 tracks the remaining medium staking callback finding and the move to a `--fail-medium` Slither gate.

No deployment is performed by this PR.