### PR TITLE
fix: prevent presale readiness checks from hanging

### DIFF
--- a/presale-config.js
+++ b/presale-config.js
@@ -9,6 +9,11 @@ window.AETHERON_PRESALE_CONFIG = {
   expectedOwner: "0x15b9F8ecedafD69Eb1dD93E51fE522690Bf6B7C2",
   expectedTreasury: "0x15b9F8ecedafD69Eb1dD93E51fE522690Bf6B7C2",
   publicRpcUrl: "https://mainnet.base.org",
+  publicRpcUrls: [
+    "https://base-rpc.publicnode.com",
+    "https://mainnet.base.org"
+  ],
+  rpcTimeoutMs: 8000,
   maxPresaleTokens: 33333333,
   network: "base",
   chainId: 8453,

--- a/presale-readiness.js
+++ b/presale-readiness.js
@@ -3,7 +3,12 @@
   const statusText = document.getElementById('presaleStatusText');
   const statusDot = document.getElementById('presaleStatusDot');
   const mobileHelp = document.getElementById('mobileWalletHelp');
-  const PUBLIC_RPC = config.publicRpcUrl || 'https://mainnet.base.org';
+  const RPC_TIMEOUT_MS = Number(config.rpcTimeoutMs) || 8000;
+  const RPC_CANDIDATES = [...new Set([
+    ...(Array.isArray(config.publicRpcUrls) ? config.publicRpcUrls : []),
+    config.publicRpcUrl,
+    'https://mainnet.base.org'
+  ].filter(Boolean))];
   const EXPECTED_OWNER = String(config.expectedOwner || '').toLowerCase();
   const EXPECTED_TREASURY = String(config.expectedTreasury || '').toLowerCase();
 
@@ -12,46 +17,84 @@
     if (statusDot) statusDot.dataset.state = state;
   }
 
+  function setFailureDetails(message) {
+    const capStatus = document.getElementById('capStatus');
+    if (!capStatus) return;
+    capStatus.textContent = '';
+    const error = document.createElement('span');
+    error.className = 'error';
+    error.textContent = message;
+    const retry = document.createElement('button');
+    retry.type = 'button';
+    retry.id = 'readinessRetry';
+    retry.textContent = 'Retry Base verification';
+    retry.addEventListener('click', verifyReadOnlyState, { once: true });
+    capStatus.append(error, retry);
+  }
+
   function failClosed(message) {
     presaleIsLive = false;
+    presaleContract = null;
     setPurchaseControlsEnabled(false, 'Unavailable');
     showStatus(message, 'blocked');
-    setHtml('capStatus', `<span class="error">${message}</span>`);
+    setFailureDetails(message);
+  }
+
+  function withTimeout(promise, label) {
+    let timer;
+    const timeout = new Promise((_, reject) => {
+      timer = window.setTimeout(() => reject(new Error(`${label} timed out.`)), RPC_TIMEOUT_MS);
+    });
+    return Promise.race([promise, timeout]).finally(() => window.clearTimeout(timer));
+  }
+
+  async function createVerifiedProvider() {
+    const failures = [];
+    for (const rpcUrl of RPC_CANDIDATES) {
+      try {
+        const candidate = new ethers.providers.JsonRpcProvider(rpcUrl, { name: 'base', chainId: 8453 });
+        const network = await withTimeout(candidate.getNetwork(), 'Base network check');
+        if (network.chainId !== 8453) throw new Error('RPC returned the wrong network.');
+        const [presaleCode, tokenCode] = await withTimeout(Promise.all([
+          candidate.getCode(PRESALE_CONTRACT_ADDRESS),
+          candidate.getCode(AETH_TOKEN_ADDRESS)
+        ]), 'Base contract bytecode check');
+        if (presaleCode === '0x' || tokenCode === '0x') throw new Error('Configured contract bytecode is missing on Base.');
+        return candidate;
+      } catch (error) {
+        failures.push(`${rpcUrl}: ${error?.message || error}`);
+      }
+    }
+    console.error('All Base RPC readiness checks failed', failures);
+    throw new Error('Unable to reach Base safely. Retry verification shortly.');
   }
 
   async function verifyReadOnlyState() {
     showStatus('Checking Base contract status…', 'checking');
+    const previousRetry = document.getElementById('readinessRetry');
+    if (previousRetry) previousRetry.disabled = true;
     if (!window.ethers || !isPresaleConfigured()) {
       failClosed('Presale configuration is incomplete.');
       return;
     }
 
     try {
-      const readProvider = new ethers.providers.JsonRpcProvider(PUBLIC_RPC, { name: 'base', chainId: 8453 });
-      const network = await readProvider.getNetwork();
-      if (network.chainId !== 8453) throw new Error('RPC returned the wrong network.');
-
-      const [presaleCode, tokenCode] = await Promise.all([
-        readProvider.getCode(PRESALE_CONTRACT_ADDRESS),
-        readProvider.getCode(AETH_TOKEN_ADDRESS)
-      ]);
-      if (presaleCode === '0x' || tokenCode === '0x') throw new Error('Configured contract bytecode is missing on Base.');
-
+      const readProvider = await createVerifiedProvider();
       const readContract = new ethers.Contract(
         PRESALE_CONTRACT_ADDRESS,
         [...PRESALE_ABI, 'function owner() view returns (address)', 'function treasury() view returns (address)'],
         readProvider
       );
-      const [owner, treasury, linkedToken] = await Promise.all([
+      const [owner, treasury, linkedToken] = await withTimeout(Promise.all([
         readContract.owner(), readContract.treasury(), readContract.token()
-      ]);
+      ]), 'Presale custody check');
       if (linkedToken.toLowerCase() !== AETH_TOKEN_ADDRESS.toLowerCase()) throw new Error('Presale token linkage does not match the published AETH token.');
       if (EXPECTED_OWNER && owner.toLowerCase() !== EXPECTED_OWNER) throw new Error('Presale ownership differs from the approved launch owner.');
       if (EXPECTED_TREASURY && treasury.toLowerCase() !== EXPECTED_TREASURY) throw new Error('Presale treasury differs from the approved launch treasury.');
 
       provider = readProvider;
       presaleContract = readContract;
-      await loadPresaleData();
+      await withTimeout(loadPresaleData(), 'Presale state and inventory check');
       if (!presaleContract) throw new Error('Unable to validate live presale parameters and inventory.');
       if (presaleIsLive) showStatus('ON-CHAIN PRESALE LIVE', 'live');
       else showStatus('Presale is not currently accepting purchases', 'blocked');
@@ -71,6 +114,7 @@
     if (coinbase) coinbase.href = `https://go.cb-w.com/dapp?cb_url=${page}`;
   }
 
+  window.retryPresaleReadiness = verifyReadOnlyState;
   window.addEventListener('load', () => {
     showMobileWalletHelp();
     verifyReadOnlyState();

--- a/smart-contract/test/PresaleFrontend.test.js
+++ b/smart-contract/test/PresaleFrontend.test.js
@@ -7,10 +7,14 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const source = await fs.readFile(path.resolve(__dirname, "../../presale.js"), "utf8");
+const readinessSource = await fs.readFile(path.resolve(__dirname, "../../presale-readiness.js"), "utf8");
+const configSource = await fs.readFile(path.resolve(__dirname, "../../presale-config.js"), "utf8");
 
 describe("presale frontend safety invariants", function () {
   it("is valid JavaScript", function () {
     assert.doesNotThrow(() => new vm.Script(source, { filename: "presale.js" }));
+    assert.doesNotThrow(() => new vm.Script(readinessSource, { filename: "presale-readiness.js" }));
+    assert.doesNotThrow(() => new vm.Script(configSource, { filename: "presale-config.js" }));
   });
 
   it("defines network constants before selecting the configured network", function () {
@@ -49,5 +53,23 @@ describe("presale frontend safety invariants", function () {
   it("enforces the contract's cumulative per-wallet contribution limit", function () {
     assert.match(source, /presaleContract\.contributions\(await signer\.getAddress\(\)\)/);
     assert.match(source, /maxContributionETH - userContributionETH/);
+  });
+
+  it("bounds Base readiness calls and fails over across published RPCs", function () {
+    assert.match(readinessSource, /const RPC_TIMEOUT_MS/);
+    assert.match(readinessSource, /Promise\.race\(\[promise, timeout\]\)/);
+    assert.match(readinessSource, /async function createVerifiedProvider\(\)/);
+    assert.match(readinessSource, /for \(const rpcUrl of RPC_CANDIDATES\)/);
+    assert.match(readinessSource, /withTimeout\(loadPresaleData\(\), 'Presale state and inventory check'\)/);
+    assert.match(configSource, /publicRpcUrls:\s*\[/);
+    assert.match(configSource, /https:\/\/base-rpc\.publicnode\.com/);
+    assert.match(configSource, /rpcTimeoutMs:\s*8000/);
+  });
+
+  it("fails closed with a user-visible retry instead of hanging", function () {
+    assert.match(readinessSource, /presaleIsLive = false/);
+    assert.match(readinessSource, /setPurchaseControlsEnabled\(false, 'Unavailable'\)/);
+    assert.match(readinessSource, /retry\.textContent = 'Retry Base verification'/);
+    assert.match(readinessSource, /retry\.addEventListener\('click', verifyReadOnlyState/);
   });
 });


### PR DESCRIPTION
## What changed

- bounds every browser-side Base RPC and presale state read with an 8-second timeout
- fails over across two published Base RPC endpoints
- keeps purchases fail-closed if every endpoint fails
- replaces the permanent `Checking…` state with a clear error and retry button
- adds regression tests for timeout, failover, fail-closed behavior, and retry UI

## Why

The production desktop page could remain indefinitely on `Checking Base contract status…` when the single rate-limited public RPC stalled. Mobile wallet purchases still worked, but the desktop readiness gate had no bounded failure path.

## Impact

No smart-contract, presale address, ownership, treasury, sale term, allocation, or production fund changes are included. This PR changes only frontend readiness behavior and its tests.

## Validation

Existing GitHub security and presale gates should run on this PR. Merge only after all required checks pass.