### PR TITLE
feat: add protected Base Sepolia presale rehearsal gate

### DIFF
--- a/.github/workflows/base-sepolia-presale-rehearsal.yml
+++ b/.github/workflows/base-sepolia-presale-rehearsal.yml
@@ -1,0 +1,157 @@
+name: Base Sepolia Presale Rehearsal
+
+on:
+  workflow_dispatch:
+    inputs:
+      broadcast:
+        description: "Deploy and exercise the Base Sepolia rehearsal contracts"
+        required: true
+        default: false
+        type: boolean
+      confirmation:
+        description: "Type DEPLOY_BASE_SEPOLIA_REHEARSAL to authorize testnet transactions"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  deployments: read
+
+concurrency:
+  group: base-sepolia-presale-rehearsal
+  cancel-in-progress: false
+
+env:
+  RELEASE_COMMIT: ${{ github.sha }}
+  BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL }}
+  PRIVATE_KEY: ${{ secrets.BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY }}
+  REHEARSAL_TREASURY_ADDRESS: ${{ vars.REHEARSAL_TREASURY_ADDRESS }}
+  MIN_REHEARSAL_BALANCE_ETH: "0.01"
+
+jobs:
+  readiness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: base-sepolia-presale
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: smart-contract/package-lock.json
+      - name: Require protected deployment environment
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          DEPLOY_ENVIRONMENT: base-sepolia-presale
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          const repository = process.env.GITHUB_REPOSITORY;
+          const environmentName = process.env.DEPLOY_ENVIRONMENT;
+          const response = await fetch(
+            `https://api.github.com/repos/${repository}/environments/${encodeURIComponent(environmentName)}`,
+            {
+              headers: {
+                Accept: "application/vnd.github+json",
+                Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+                "X-GitHub-Api-Version": "2022-11-28",
+              },
+            }
+          );
+          if (!response.ok) throw new Error(`Cannot validate ${environmentName}: HTTP ${response.status}`);
+          const environment = await response.json();
+          const rules = Array.isArray(environment.protection_rules) ? environment.protection_rules : [];
+          const reviewerRule = rules.find((rule) => rule.type === "required_reviewers");
+          if (!reviewerRule?.reviewers?.length) throw new Error(`${environmentName} needs a deployment reviewer`);
+          const branchPolicy = environment.deployment_branch_policy;
+          if (!branchPolicy?.protected_branches && !branchPolicy?.custom_branch_policies) {
+            throw new Error(`${environmentName} needs deployment branch restrictions`);
+          }
+          console.log(`Protected environment ${environmentName}: PASS`);
+          NODE
+      - name: Install exact dependencies
+        working-directory: smart-contract
+        run: npm ci
+      - name: Compile exact artifacts
+        working-directory: smart-contract
+        run: npm run compile
+      - name: Run presale and staking tests
+        working-directory: smart-contract
+        run: npm test
+      - name: Validate Base Sepolia signer, RPC, balance, and artifacts
+        working-directory: smart-contract
+        env:
+          DRY_RUN: "true"
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run rehearsal:base-sepolia:presale 2>&1 | tee ../base-sepolia-presale-readiness.log
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: base-sepolia-presale-readiness-${{ github.run_id }}
+          path: base-sepolia-presale-readiness.log
+          if-no-files-found: error
+
+  deploy-and-exercise:
+    needs: readiness
+    if: ${{ inputs.broadcast && inputs.confirmation == 'DEPLOY_BASE_SEPOLIA_REHEARSAL' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: base-sepolia-presale
+    env:
+      CONFIRM_BASE_SEPOLIA_REHEARSAL: ${{ inputs.confirmation }}
+      BASESCAN_API_KEY: ${{ secrets.BASESCAN_API_KEY || secrets.ETHERSCAN_API_KEY }}
+      ALLOW_REHEARSAL_OVERWRITE: "true"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: smart-contract/package-lock.json
+      - name: Install exact dependencies
+        working-directory: smart-contract
+        run: npm ci
+      - name: Compile exact artifacts
+        working-directory: smart-contract
+        run: npm run compile
+      - name: Deploy and exercise presale and staking paths
+        working-directory: smart-contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run rehearsal:base-sepolia:presale 2>&1 | tee ../base-sepolia-presale-deployment.log
+      - name: Verify all rehearsal sources on BaseScan Sepolia
+        working-directory: smart-contract
+        env:
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run verify:base-sepolia:rehearsal 2>&1 | tee ../base-sepolia-presale-source-verification.log
+      - name: Record immutable manifest digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha256sum smart-contract/deployments/base-sepolia-presale-rehearsal.json \
+            | tee base-sepolia-presale-manifest.sha256
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: base-sepolia-presale-rehearsal-${{ github.run_id }}
+          path: |
+            smart-contract/deployments/base-sepolia-presale-rehearsal.json
+            base-sepolia-presale-deployment.log
+            base-sepolia-presale-source-verification.log
+            base-sepolia-presale-manifest.sha256
+          if-no-files-found: error
+      - name: Rehearsal summary
+        if: always()
+        shell: bash
+        run: |
+          echo "Release commit: $GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
+          echo "The artifact binds contract addresses, transaction hashes, runtime bytecode hashes, functional assertions, explorer verification, and a SHA-256 manifest digest." >> "$GITHUB_STEP_SUMMARY"
+          echo "No Base mainnet transaction is authorized by this workflow." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/BASE_SEPOLIA_REHEARSAL_RUNBOOK.md
+++ b/docs/BASE_SEPOLIA_REHEARSAL_RUNBOOK.md
@@ -1,0 +1,122 @@
+# Base Sepolia Presale Rehearsal Runbook
+
+This runbook is the mandatory testnet gate before any new Aetheron Platform mainnet launch action. It does not authorize Base mainnet transactions.
+
+## Frozen rehearsal scope
+
+The protected workflow deploys fresh Base Sepolia-only contracts from the reviewed commit:
+
+- `MockAETH`
+- `AetheronPresaleV2` success-path instance
+- `AetheronPresaleV2` refund-path instance
+- `AetheronStaking`
+
+The workflow never changes the published Base mainnet token or presale. Testnet contracts are disposable evidence targets.
+
+## Protected environment
+
+Create the GitHub environment `base-sepolia-presale` with:
+
+- at least one required deployment reviewer;
+- deployment branch restrictions allowing only the reviewed release branch or `main`;
+- secret `BASE_SEPOLIA_RPC_URL`;
+- secret `BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY`;
+- secret `BASESCAN_API_KEY` or `ETHERSCAN_API_KEY`;
+- optional environment variable `REHEARSAL_TREASURY_ADDRESS`.
+
+The deployer must hold at least `0.01` Base Sepolia ETH. The treasury may equal the deployer for a disposable testnet rehearsal, but production ownership and treasury separation remain a separate mainnet gate.
+
+## Phase 1: readiness
+
+Run **Base Sepolia Presale Rehearsal** with:
+
+- `broadcast`: `false`
+- `confirmation`: blank
+
+The readiness job must pass all of the following:
+
+1. protected environment reviewer and branch-policy validation;
+2. exact dependency installation;
+3. Solidity compilation;
+4. the repository presale and staking test suite;
+5. Base Sepolia chain ID `84532` validation;
+6. deployer-key and balance validation;
+7. deployment artifact validation.
+
+The job uploads `base-sepolia-presale-readiness-<run-id>` even when a later step fails.
+
+## Phase 2: guarded rehearsal
+
+Only after readiness is green, rerun with:
+
+- `broadcast`: `true`
+- `confirmation`: `DEPLOY_BASE_SEPOLIA_REHEARSAL`
+
+Approve the protected environment. The workflow then performs these on-chain checks:
+
+### Presale success path
+
+1. deploy and fund a fresh success-path presale;
+2. wait for the sale start;
+3. buy exactly the configured hard cap;
+4. finalize the sale;
+5. claim purchased tokens;
+6. withdraw raised test ETH to the rehearsal treasury;
+7. confirm the presale retains no ETH and no unclaimed buyer allocation.
+
+### Presale refund path
+
+1. deploy and fund a separate refund-path presale;
+2. buy below its hard cap;
+3. cancel as owner;
+4. claim the contributor refund;
+5. confirm the contribution and contract ETH balance are cleared.
+
+### Staking and privilege path
+
+1. deploy staking against the fresh mock token;
+2. deposit test rewards;
+3. stake into pool `0`;
+4. confirm an early normal unstake is rejected by the production lock rules;
+5. exercise `emergencyUnstake` and confirm all stake accounting is cleared;
+6. confirm non-owner presale cancellation is rejected;
+7. confirm non-owner pool administration is rejected.
+
+A normal time-locked unstake still requires the contract's one-hour minimum and pool lock duration. The exact lock behavior remains covered by the repository test suite; the public-chain rehearsal proves the lock rejection and emergency exit without weakening production constants.
+
+## Source verification and immutable evidence
+
+The workflow submits all four deployed contracts to BaseScan Sepolia through the Etherscan V2 API and reads the verified source back. The uploaded rehearsal artifact must include:
+
+- workflow run ID and reviewed commit SHA;
+- deployer and treasury addresses;
+- every deployed contract address;
+- every deployment and functional transaction hash;
+- deployment block numbers and gas used;
+- runtime bytecode hashes;
+- constructor arguments;
+- successful and rejected-path assertions;
+- BaseScan source-verification URLs;
+- `base-sepolia-presale-manifest.sha256`.
+
+The canonical manifest is:
+
+`smart-contract/deployments/base-sepolia-presale-rehearsal.json`
+
+Its final status must be `verified-rehearsal`.
+
+## Evidence acceptance
+
+Do not mark the Base Sepolia section of `docs/LAUNCH_HARDENING_CHECKLIST.md` complete until the exact workflow run URL, artifact, manifest digest, and explorer links have been reviewed and retained. Do not copy testnet addresses into the production frontend.
+
+## Mainnet gate
+
+A successful rehearsal is necessary but not sufficient for mainnet. Mainnet still requires:
+
+- resolution or formal acceptance of remaining security findings;
+- required branch-protection checks on `main`;
+- production multisig and timelock ownership review;
+- two-person parameter review;
+- final bytecode and source verification;
+- owner-wallet smoke purchase authorization;
+- rollback and incident-response evidence.

--- a/docs/LAUNCH_HARDENING_CHECKLIST.md
+++ b/docs/LAUNCH_HARDENING_CHECKLIST.md
@@ -16,19 +16,23 @@
 - [ ] Confirm token decimals and all price conversion formulas.
 - [ ] Confirm per-wallet minimum and maximum purchase limits.
 - [ ] Confirm global hard cap and sold-out behavior.
-- [ ] Confirm pause/unpause and emergency withdrawal permissions.
+- [ ] Confirm cancellation/refund and emergency withdrawal permissions.
 - [ ] Confirm claim schedule, repeated-claim protection, and refund behavior.
 - [ ] Test zero-value, boundary, stale-price, malicious-token, and reentrancy cases.
 
 ## Base Sepolia rehearsal
 
-- [ ] Deploy all production contracts to Base Sepolia.
-- [ ] Verify every contract on the explorer.
-- [ ] Record implementation and proxy addresses separately.
-- [ ] Configure treasury, multisig, token allocation, caps, and sale windows.
-- [ ] Fund the sale and reward pools.
-- [ ] Execute buy, claim, stake, unstake, pause, unpause, and withdrawal flows.
-- [ ] Save transaction hashes and screenshots in deployment evidence.
+Automation and the evidence contract are defined in `docs/BASE_SEPOLIA_REHEARSAL_RUNBOOK.md`. Keep every item below unchecked until a reviewed workflow artifact proves it.
+
+- [ ] Protected `base-sepolia-presale` environment requires a reviewer and restricted deployment branch.
+- [ ] Readiness run passes from the exact reviewed commit.
+- [ ] Deploy fresh test token, success presale, refund presale, and staking contracts to Base Sepolia.
+- [ ] Verify every rehearsal contract on BaseScan Sepolia.
+- [ ] Execute buy, finalize, claim, treasury withdrawal, cancellation, and contributor refund flows.
+- [ ] Execute stake, locked-unstake rejection, and emergency-unstake flows.
+- [ ] Confirm non-owner presale and staking administration calls are rejected.
+- [ ] Archive addresses, transaction hashes, runtime bytecode hashes, constructor arguments, logs, and the manifest SHA-256 digest.
+- [ ] Record the exact workflow run URL and artifact retention location.
 
 ## Mainnet readiness
 
@@ -44,7 +48,7 @@
 
 - [ ] `MAINNET_EVIDENCE_CHECKLIST.md` completed.
 - [ ] Release notes include commit SHA and deployed bytecode hashes.
-- [ ] CI run links and Slither/Forge results archived.
+- [ ] CI run links and Slither/contract-test results archived.
 - [ ] Deployment transaction hashes recorded.
 - [ ] Ownership-transfer and timelock transactions recorded.
-- [ ] Incident response contacts and pause procedure documented.
+- [ ] Incident response contacts and cancellation/refund procedure documented.

--- a/smart-contract/package.json
+++ b/smart-contract/package.json
@@ -16,6 +16,8 @@
     "deploy:presale": "node scripts/deploy-base-presale-bounded.mjs",
     "deploy:presale:base:safe": "node scripts/deploy-base-presale-bounded.mjs",
     "deploy:base-presale:dry-run": "DRY_RUN=true node scripts/deploy-base-presale-bounded.mjs",
+    "rehearsal:base-sepolia:presale": "node scripts/deploy-base-sepolia-presale-rehearsal.mjs",
+    "verify:base-sepolia:rehearsal": "node scripts/verify-base-sepolia-rehearsal.mjs",
     "cancel:invalid-base-presale": "node scripts/cancel-invalid-base-presale.mjs",
     "test:coverage": "node -e \"console.log('Coverage tooling was removed during dependency hardening. Re-add solidity-coverage if you need contract coverage reports.')\"",
     "deploy:local": "hardhat run scripts/deploy.mjs --network hardhat",

--- a/smart-contract/scripts/deploy-base-sepolia-presale-rehearsal.mjs
+++ b/smart-contract/scripts/deploy-base-sepolia-presale-rehearsal.mjs
@@ -1,0 +1,329 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import dotenv from "dotenv";
+import { ethers } from "ethers";
+
+dotenv.config();
+
+const EXPECTED_CHAIN_ID = 84532n;
+const CONFIRMATION = "DEPLOY_BASE_SEPOLIA_REHEARSAL";
+const DEFAULT_PURCHASE_ETH = "0.0001";
+const DEFAULT_RATE = 1_000_000n;
+const DEFAULT_START_DELAY_SECONDS = 20;
+const DEFAULT_DURATION_SECONDS = 3600;
+const DEFAULT_MIN_BALANCE_ETH = "0.01";
+
+function required(name) {
+  const value = String(process.env[name] || "").trim().replace(/^['"]|['"]$/g, "");
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function normalizePrivateKey(value) {
+  const key = String(value || "").trim().replace(/^['"]|['"]$/g, "");
+  return key.startsWith("0x") ? key : `0x${key}`;
+}
+
+function loadArtifact(smartContractDir, sourceName, contractName) {
+  const artifactPath = path.join(
+    smartContractDir,
+    "artifacts",
+    "contracts",
+    sourceName,
+    `${contractName}.json`
+  );
+  if (!fs.existsSync(artifactPath)) {
+    throw new Error(`Missing artifact ${artifactPath}; run npm run compile first`);
+  }
+  return JSON.parse(fs.readFileSync(artifactPath, "utf8"));
+}
+
+async function waitUntil(provider, targetTimestamp) {
+  for (let attempt = 1; attempt <= 60; attempt += 1) {
+    const block = await provider.getBlock("latest");
+    if (block && block.timestamp >= targetTimestamp) return block.timestamp;
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+  throw new Error(`Base Sepolia did not reach sale start timestamp ${targetTimestamp}`);
+}
+
+function transactionEvidence(receipt) {
+  return {
+    hash: receipt.hash,
+    blockNumber: receipt.blockNumber,
+    status: receipt.status,
+    gasUsed: receipt.gasUsed?.toString() || null,
+  };
+}
+
+async function expectRevert(label, operation) {
+  try {
+    await operation();
+  } catch (error) {
+    return error?.shortMessage || error?.reason || error?.message || String(error);
+  }
+  throw new Error(`${label} unexpectedly succeeded`);
+}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const smartContractDir = path.resolve(scriptDir, "..");
+const deploymentPath = path.join(
+  smartContractDir,
+  "deployments",
+  "base-sepolia-presale-rehearsal.json"
+);
+
+const rpcUrl = required("BASE_SEPOLIA_RPC_URL");
+const privateKey = normalizePrivateKey(required("PRIVATE_KEY"));
+assert(/^0x[0-9a-fA-F]{64}$/.test(privateKey), "PRIVATE_KEY must be a 32-byte hexadecimal key");
+
+const dryRun = process.env.DRY_RUN === "true";
+if (!dryRun) {
+  assert(
+    process.env.CONFIRM_BASE_SEPOLIA_REHEARSAL === CONFIRMATION,
+    `CONFIRM_BASE_SEPOLIA_REHEARSAL must equal ${CONFIRMATION}`
+  );
+}
+
+const provider = new ethers.JsonRpcProvider(rpcUrl, Number(EXPECTED_CHAIN_ID), {
+  staticNetwork: true,
+  batchMaxCount: 1,
+});
+const wallet = new ethers.Wallet(privateKey, provider);
+const network = await provider.getNetwork();
+assert(network.chainId === EXPECTED_CHAIN_ID, `Expected chain 84532, received ${network.chainId}`);
+
+const balance = await provider.getBalance(wallet.address);
+const minimumBalance = ethers.parseEther(process.env.MIN_REHEARSAL_BALANCE_ETH || DEFAULT_MIN_BALANCE_ETH);
+assert(
+  balance >= minimumBalance,
+  `Rehearsal deployer ${wallet.address} has ${ethers.formatEther(balance)} ETH; at least ${ethers.formatEther(minimumBalance)} ETH is required`
+);
+
+const treasury = String(process.env.REHEARSAL_TREASURY_ADDRESS || wallet.address).trim();
+assert(ethers.isAddress(treasury) && treasury !== ethers.ZeroAddress, "REHEARSAL_TREASURY_ADDRESS is invalid");
+
+const tokenArtifact = loadArtifact(smartContractDir, "MockAETH.sol", "MockAETH");
+const presaleArtifact = loadArtifact(smartContractDir, "AetheronPresale.sol", "AetheronPresaleV2");
+const stakingArtifact = loadArtifact(smartContractDir, "AetheronStaking.sol", "AetheronStaking");
+
+const purchaseWei = ethers.parseEther(process.env.REHEARSAL_PURCHASE_ETH || DEFAULT_PURCHASE_ETH);
+const rate = BigInt(process.env.REHEARSAL_RATE || DEFAULT_RATE.toString());
+const startDelay = Number(process.env.REHEARSAL_START_DELAY_SECONDS || DEFAULT_START_DELAY_SECONDS);
+const duration = Number(process.env.REHEARSAL_DURATION_SECONDS || DEFAULT_DURATION_SECONDS);
+assert(purchaseWei > 0n, "REHEARSAL_PURCHASE_ETH must be positive");
+assert(rate > 0n, "REHEARSAL_RATE must be positive");
+assert(startDelay >= 5 && startDelay <= 300, "REHEARSAL_START_DELAY_SECONDS must be between 5 and 300");
+assert(duration >= 300, "REHEARSAL_DURATION_SECONDS must be at least 300");
+
+const readiness = {
+  chainId: network.chainId.toString(),
+  deployer: wallet.address,
+  deployerBalanceEth: ethers.formatEther(balance),
+  treasury,
+  purchaseEth: ethers.formatEther(purchaseWei),
+  rate: rate.toString(),
+  releaseCommit: process.env.RELEASE_COMMIT || process.env.GITHUB_SHA || null,
+  dryRun,
+};
+console.log(JSON.stringify({ rehearsalReadiness: readiness }, null, 2));
+
+if (dryRun) {
+  console.log("BASE SEPOLIA PRESALE REHEARSAL READINESS: PASS");
+  process.exit(0);
+}
+
+fs.mkdirSync(path.dirname(deploymentPath), { recursive: true });
+if (fs.existsSync(deploymentPath) && process.env.ALLOW_REHEARSAL_OVERWRITE !== "true") {
+  throw new Error(`Refusing to overwrite ${deploymentPath}; set ALLOW_REHEARSAL_OVERWRITE=true for an intentional rerun`);
+}
+
+const manifest = {
+  schemaVersion: 1,
+  status: "deploying",
+  network: "base-sepolia",
+  chainId: Number(EXPECTED_CHAIN_ID),
+  releaseCommit: readiness.releaseCommit,
+  workflowRunId: process.env.GITHUB_RUN_ID || null,
+  deployer: wallet.address,
+  treasury,
+  startedAt: new Date().toISOString(),
+  completedAt: null,
+  parameters: {
+    purchaseWei: purchaseWei.toString(),
+    rate: rate.toString(),
+    startDelaySeconds: startDelay,
+    durationSeconds: duration,
+  },
+  contracts: {},
+  transactions: {},
+  assertions: {},
+};
+
+function persist(status = manifest.status) {
+  manifest.status = status;
+  fs.writeFileSync(deploymentPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+async function deployContract(label, artifact, constructorArguments) {
+  const factory = new ethers.ContractFactory(artifact.abi, artifact.bytecode, wallet);
+  const contract = await factory.deploy(...constructorArguments);
+  const transaction = contract.deploymentTransaction();
+  const receipt = await transaction.wait();
+  const address = await contract.getAddress();
+  const runtimeCode = await provider.getCode(address);
+  assert(runtimeCode !== "0x", `${label} runtime bytecode is missing`);
+  manifest.contracts[label] = {
+    address,
+    source: artifact.sourceName,
+    contractName: artifact.contractName,
+    constructorArguments: constructorArguments.map((value) => value.toString()),
+    deployment: transactionEvidence(receipt),
+    runtimeCodeHash: ethers.keccak256(runtimeCode),
+  };
+  persist();
+  return contract;
+}
+
+persist();
+const token = await deployContract("MockAETH", tokenArtifact, []);
+const latestBlock = await provider.getBlock("latest");
+assert(latestBlock, "Unable to read the latest Base Sepolia block");
+const startTime = latestBlock.timestamp + startDelay;
+const endTime = startTime + duration;
+
+const successHardCap = purchaseWei;
+const successFunding = successHardCap * rate;
+const refundHardCap = purchaseWei * 2n;
+const refundFunding = refundHardCap * rate;
+
+const successPresale = await deployContract("SuccessPresale", presaleArtifact, [
+  await token.getAddress(),
+  rate,
+  successHardCap,
+  successHardCap,
+  purchaseWei,
+  purchaseWei,
+  startTime,
+  endTime,
+  treasury,
+]);
+const refundPresale = await deployContract("RefundPresale", presaleArtifact, [
+  await token.getAddress(),
+  rate,
+  refundHardCap,
+  refundHardCap,
+  purchaseWei,
+  refundHardCap,
+  startTime,
+  endTime,
+  treasury,
+]);
+const staking = await deployContract("AetheronStaking", stakingArtifact, [await token.getAddress()]);
+
+for (const [label, contract, amount] of [
+  ["fundSuccessPresale", successPresale, successFunding],
+  ["fundRefundPresale", refundPresale, refundFunding],
+]) {
+  const tx = await token.transfer(await contract.getAddress(), amount);
+  manifest.transactions[label] = transactionEvidence(await tx.wait());
+  persist();
+}
+
+const stakeAmount = ethers.parseUnits("100", 18);
+const rewardAmount = ethers.parseUnits("1000", 18);
+let tx = await token.approve(await staking.getAddress(), stakeAmount + rewardAmount);
+manifest.transactions.approveStaking = transactionEvidence(await tx.wait());
+tx = await staking.depositRewards(rewardAmount);
+manifest.transactions.depositStakingRewards = transactionEvidence(await tx.wait());
+
+await waitUntil(provider, startTime);
+
+const nonOwner = ethers.Wallet.createRandom().address;
+manifest.assertions.nonOwnerCancelRejected = await expectRevert(
+  "non-owner presale cancellation",
+  () =>
+    provider.call({
+      to: successPresale.target,
+      from: nonOwner,
+      data: successPresale.interface.encodeFunctionData("cancel"),
+    })
+);
+manifest.assertions.nonOwnerPoolUpdateRejected = await expectRevert(
+  "non-owner staking pool update",
+  () =>
+    provider.call({
+      to: staking.target,
+      from: nonOwner,
+      data: staking.interface.encodeFunctionData("updatePoolStatus", [0, false]),
+    })
+);
+
+// Successful sale path: buy -> finalize at hard cap -> claim -> treasury withdrawal.
+tx = await successPresale.buyTokens({ value: purchaseWei });
+manifest.transactions.successBuy = transactionEvidence(await tx.wait());
+assert((await successPresale.weiRaised()) === successHardCap, "Successful sale hard cap was not reached");
+tx = await successPresale.finalize();
+manifest.transactions.successFinalize = transactionEvidence(await tx.wait());
+const tokenBalanceBeforeClaim = await token.balanceOf(wallet.address);
+tx = await successPresale.claimTokens();
+manifest.transactions.successClaim = transactionEvidence(await tx.wait());
+const tokenBalanceAfterClaim = await token.balanceOf(wallet.address);
+assert(tokenBalanceAfterClaim - tokenBalanceBeforeClaim === successFunding, "Claimed token amount is incorrect");
+tx = await successPresale.withdrawFunds();
+manifest.transactions.successWithdraw = transactionEvidence(await tx.wait());
+assert((await provider.getBalance(successPresale.target)) === 0n, "Successful sale retained ETH after withdrawal");
+
+// Refund path: buy below hard cap -> cancel -> contributor pulls refund.
+const walletEthBeforeRefundPurchase = await provider.getBalance(wallet.address);
+tx = await refundPresale.buyTokens({ value: purchaseWei });
+manifest.transactions.refundBuy = transactionEvidence(await tx.wait());
+tx = await refundPresale.cancel();
+manifest.transactions.refundCancel = transactionEvidence(await tx.wait());
+assert(await refundPresale.refundsAvailable(), "Refunds are not available after cancellation");
+tx = await refundPresale.claimRefund();
+manifest.transactions.refundClaim = transactionEvidence(await tx.wait());
+assert((await refundPresale.contributions(wallet.address)) === 0n, "Refund did not clear the contribution");
+assert((await provider.getBalance(refundPresale.target)) === 0n, "Refund sale retained contributor ETH");
+const walletEthAfterRefund = await provider.getBalance(wallet.address);
+manifest.assertions.refundReturnedPrincipal =
+  walletEthAfterRefund > walletEthBeforeRefundPurchase - purchaseWei;
+
+// Staking path: stake -> verify normal lock -> emergency unstake.
+tx = await staking.stake(0, stakeAmount);
+manifest.transactions.stake = transactionEvidence(await tx.wait());
+assert((await staking.getUserStakesCount(wallet.address)) === 1n, "Stake record was not created");
+manifest.assertions.earlyUnstakeRejected = await expectRevert("early unstake", () => staking.unstake.staticCall(0));
+tx = await staking.emergencyUnstake(0);
+manifest.transactions.emergencyUnstake = transactionEvidence(await tx.wait());
+assert((await staking.getUserStakesCount(wallet.address)) === 0n, "Emergency unstake did not clear the stake");
+assert((await staking.totalStaked()) === 0n, "Emergency unstake did not clear totalStaked");
+
+manifest.assertions = {
+  ...manifest.assertions,
+  successFinalized: await successPresale.finalized(),
+  successWeiRaised: (await successPresale.weiRaised()).toString(),
+  successTokensClaimed: (await successPresale.tokensOwed(wallet.address)) === 0n,
+  refundCancelled: await refundPresale.cancelled(),
+  refundContributionCleared: (await refundPresale.contributions(wallet.address)) === 0n,
+  stakingEmergencyExitCleared: (await staking.getUserStakesCount(wallet.address)) === 0n,
+};
+manifest.status = "verified-rehearsal-awaiting-source-verification";
+manifest.completedAt = new Date().toISOString();
+persist();
+
+const digest = crypto.createHash("sha256").update(fs.readFileSync(deploymentPath)).digest("hex");
+console.log(JSON.stringify({
+  rehearsal: "passed",
+  manifestPath: deploymentPath,
+  manifestSha256: digest,
+  contracts: Object.fromEntries(
+    Object.entries(manifest.contracts).map(([name, value]) => [name, value.address])
+  ),
+}, null, 2));

--- a/smart-contract/scripts/verify-base-sepolia-rehearsal.mjs
+++ b/smart-contract/scripts/verify-base-sepolia-rehearsal.mjs
@@ -1,0 +1,185 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import dotenv from "dotenv";
+import { ethers } from "ethers";
+
+dotenv.config();
+
+const CHAIN_ID = "84532";
+const API_URL = "https://api.etherscan.io/v2/api";
+const API_KEY = process.env.ETHERSCAN_API_KEY || process.env.BASESCAN_API_KEY;
+if (!API_KEY) throw new Error("ETHERSCAN_API_KEY or BASESCAN_API_KEY is required");
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const smartContractDir = path.resolve(scriptDir, "..");
+const deploymentPath = path.join(
+  smartContractDir,
+  "deployments",
+  "base-sepolia-presale-rehearsal.json"
+);
+const buildInfoDir = path.join(smartContractDir, "artifacts", "build-info");
+if (!fs.existsSync(deploymentPath)) throw new Error("Base Sepolia rehearsal manifest is missing");
+if (!fs.existsSync(buildInfoDir)) throw new Error("Hardhat build-info is missing; run npm run compile first");
+
+const manifest = JSON.parse(fs.readFileSync(deploymentPath, "utf8"));
+if (manifest.chainId !== Number(CHAIN_ID)) throw new Error(`Expected rehearsal chain ${CHAIN_ID}`);
+if (!String(manifest.status || "").startsWith("verified-rehearsal")) {
+  throw new Error(`Rehearsal manifest is not ready for verification: ${manifest.status}`);
+}
+
+const buildInfoFiles = fs.readdirSync(buildInfoDir).filter((name) => name.endsWith(".json"));
+const buildInfoCache = buildInfoFiles.map((file) => {
+  const fullPath = path.join(buildInfoDir, file);
+  const candidate = JSON.parse(fs.readFileSync(fullPath, "utf8"));
+  const output = candidate.output || (file.endsWith(".output.json") ? candidate : undefined);
+  let metadata = candidate;
+  if (!candidate.input && file.endsWith(".output.json")) {
+    const metadataPath = path.join(buildInfoDir, file.replace(/\.output\.json$/, ".json"));
+    if (fs.existsSync(metadataPath)) metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+  }
+  return metadata.input && output ? { ...metadata, output } : null;
+}).filter(Boolean);
+
+function findBuildInfo(contractName) {
+  for (const buildInfo of buildInfoCache) {
+    const sourceName = Object.keys(buildInfo.output?.contracts || {}).find(
+      (name) => buildInfo.output.contracts[name]?.[contractName]
+    );
+    if (sourceName) return { buildInfo, sourceName };
+  }
+  throw new Error(`Unable to locate ${contractName} in Hardhat build-info`);
+}
+
+function constructorEncoding(label, record) {
+  const args = record.constructorArguments || [];
+  if (label === "MockAETH") return "";
+  if (label === "AetheronStaking") {
+    return ethers.AbiCoder.defaultAbiCoder().encode(["address"], args).slice(2);
+  }
+  if (label === "SuccessPresale" || label === "RefundPresale") {
+    return ethers.AbiCoder.defaultAbiCoder().encode(
+      ["address", "uint256", "uint256", "uint256", "uint256", "uint256", "uint256", "uint256", "address"],
+      [
+        args[0],
+        BigInt(args[1]),
+        BigInt(args[2]),
+        BigInt(args[3]),
+        BigInt(args[4]),
+        BigInt(args[5]),
+        BigInt(args[6]),
+        BigInt(args[7]),
+        args[8],
+      ]
+    ).slice(2);
+  }
+  throw new Error(`Unsupported rehearsal contract label: ${label}`);
+}
+
+async function etherscanRequest(values, method = "POST") {
+  const params = new URLSearchParams({ apikey: API_KEY, chainid: CHAIN_ID, ...values });
+  const response = method === "GET"
+    ? await fetch(`${API_URL}?${params.toString()}`)
+    : await fetch(`${API_URL}?chainid=${CHAIN_ID}`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: params,
+      });
+  if (!response.ok) throw new Error(`Etherscan HTTP ${response.status}`);
+  return response.json();
+}
+
+async function verifyContract(label, record) {
+  if (!ethers.isAddress(record.address || "")) throw new Error(`${label} address is invalid`);
+  const contractName = record.contractName;
+  const { buildInfo, sourceName } = findBuildInfo(contractName);
+  const compilerVersion = `v${buildInfo.solcLongVersion || buildInfo.solcVersion}`;
+  const constructorArguments = constructorEncoding(label, record);
+  const fullyQualifiedName = `${sourceName}:${contractName}`;
+
+  const submission = await etherscanRequest({
+    module: "contract",
+    action: "verifysourcecode",
+    contractaddress: record.address,
+    sourceCode: JSON.stringify(buildInfo.input),
+    codeformat: "solidity-standard-json-input",
+    contractname: fullyQualifiedName,
+    compilerversion: compilerVersion,
+    optimizationUsed: buildInfo.input.settings?.optimizer?.enabled ? "1" : "0",
+    runs: String(buildInfo.input.settings?.optimizer?.runs || 200),
+    constructorArguments,
+    evmversion: buildInfo.input.settings?.evmVersion || "default",
+    licenseType: "3",
+  });
+
+  if (submission.status !== "1") {
+    const text = String(submission.result || submission.message || "Unknown verification error");
+    if (!/already verified/i.test(text)) throw new Error(`${label} verification submission failed: ${text}`);
+  } else {
+    const guid = submission.result;
+    let verified = false;
+    for (let attempt = 1; attempt <= 30; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+      const status = await etherscanRequest({
+        module: "contract",
+        action: "checkverifystatus",
+        guid,
+      });
+      const result = String(status.result || status.message || "");
+      console.log(`${label} verification attempt ${attempt}: ${result}`);
+      if (/pass - verified/i.test(result)) {
+        verified = true;
+        break;
+      }
+      if (!/pending in queue/i.test(result)) throw new Error(`${label} verification failed: ${result}`);
+    }
+    if (!verified) throw new Error(`${label} verification did not complete before timeout`);
+  }
+
+  const sourceCheck = await etherscanRequest({
+    module: "contract",
+    action: "getsourcecode",
+    address: record.address,
+  }, "GET");
+  const verifiedRecord = sourceCheck.result?.[0];
+  if (sourceCheck.status !== "1" || !verifiedRecord?.SourceCode) {
+    throw new Error(`${label} source-code readback did not confirm verification`);
+  }
+  const readbackArgs = String(verifiedRecord.ConstructorArguments || "").replace(/^0x/i, "").toLowerCase();
+  if (readbackArgs !== constructorArguments.toLowerCase()) {
+    throw new Error(`${label} constructor-argument readback differs from the manifest`);
+  }
+
+  return {
+    explorer: "BaseScan Sepolia",
+    api: "Etherscan V2",
+    chainId: Number(CHAIN_ID),
+    verified: true,
+    verifiedAt: new Date().toISOString(),
+    contractName: fullyQualifiedName,
+    compilerVersion,
+    constructorArguments,
+    url: `https://sepolia.basescan.org/address/${record.address}#code`,
+  };
+}
+
+for (const label of ["MockAETH", "SuccessPresale", "RefundPresale", "AetheronStaking"]) {
+  const record = manifest.contracts?.[label];
+  if (!record) throw new Error(`Manifest is missing ${label}`);
+  record.verification = await verifyContract(label, record);
+  fs.writeFileSync(deploymentPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+manifest.status = "verified-rehearsal";
+manifest.sourceVerificationCompletedAt = new Date().toISOString();
+fs.writeFileSync(deploymentPath, `${JSON.stringify(manifest, null, 2)}\n`);
+const digest = crypto.createHash("sha256").update(fs.readFileSync(deploymentPath)).digest("hex");
+console.log(JSON.stringify({
+  sourceVerification: "passed",
+  manifestPath: deploymentPath,
+  manifestSha256: digest,
+  explorerUrls: Object.fromEntries(
+    Object.entries(manifest.contracts).map(([label, record]) => [label, record.verification.url])
+  ),
+}, null, 2));


### PR DESCRIPTION
## What this finishes

Implements the missing Base Sepolia rehearsal milestone from #206 without authorizing a Base mainnet transaction.

## Included

- protected `Base Sepolia Presale Rehearsal` workflow with reviewer and branch-policy validation
- readiness-only mode that checks chain ID, signer, balance, artifacts, compilation, and tests
- guarded testnet broadcast requiring `DEPLOY_BASE_SEPOLIA_REHEARSAL`
- fresh `MockAETH`, success-path presale, refund-path presale, and staking deployments
- on-chain buy/finalize/claim/withdraw and buy/cancel/refund paths
- staking, locked-unstake rejection, emergency unstake, and non-owner rejection checks
- runtime bytecode hashes, constructor arguments, transaction evidence, and immutable manifest digest
- BaseScan Sepolia source submission and readback for all rehearsal contracts
- evidence-backed runbook and launch-hardening checklist

## Operator configuration after merge

Create protected environment `base-sepolia-presale` with a required reviewer, restricted deployment branches, `BASE_SEPOLIA_RPC_URL`, `BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY`, and `BASESCAN_API_KEY` or `ETHERSCAN_API_KEY`. Fund the deployer with at least `0.01` Base Sepolia ETH.

Tracks #206. Keep that issue open until a reviewed workflow artifact reaches manifest status `verified-rehearsal`.