### PR TITLE
docs: Aug 11 status — #217 rehearsal still open; launch still blocked

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,7 +1,7 @@
 # Aetheron Platform — Canonical Project Status
 
 **Status:** Active flagship  
-**Last updated:** 2026-08-09  
+**Last updated:** 2026-08-11  
 **Canonical role:** Commercial Aetheron product: AETH token, presale, staking, public frontend, wallet onboarding, and treasury-facing operations.
 
 ## Production truth
@@ -10,7 +10,7 @@
 - Canonical AETH token: `0xecf7E17faE148C01E1b5008A31Dfd2d1B6608E4e`.
 - Creation transaction: `0x53c1a82cd949b5ad01e0656934ba3903c7d6e202ab2f4606f321a7c152346829`.
 - Contract source verification is recorded in `smart-contract/deployments/aeth-base.json`.
-- Token trading is currently recorded as **disabled**.
+- Token trading is currently recorded as **disabled** in the canonical release model (any on-chain enablement does not by itself constitute production launch approval).
 - Polygon Mumbai, Polygon mainnet, Solana, and any earlier AETH addresses are **legacy deployments** unless separately revalidated and entered into the canonical registry.
 
 ## In scope
@@ -37,11 +37,13 @@
 - [ ] Complete an independent smart-contract review
 - [ ] Authorize any Base mainnet presale action separately (issue #219) — testnet rehearsal does **not** authorize mainnet
 - [x] Decide and document the trading-enablement and liquidity plan — **draft published** at `docs/TRADING_AND_LIQUIDITY_PLAN.md` (execution still blocked until #219)
-- [ ] Remove remaining stale Polygon-first instructions where still present
+- [ ] Remove remaining stale Polygon-first instructions where still present (#214)
 
 **Evidence templates (fill after rehearsal):**
 - `docs/evidence/BASE_SEPOLIA_REHEARSAL_TEMPLATE.md`
 - `docs/evidence/base-sepolia-rehearsal.template.json`
+
+**Status snapshot:** `docs/STATUS_2026-08-11.md`
 
 **Trading plan:**
 - `docs/TRADING_AND_LIQUIDITY_PLAN.md` (draft only; not authorized for execution)

--- a/docs/STATUS_2026-08-11.md
+++ b/docs/STATUS_2026-08-11.md
@@ -1,0 +1,41 @@
+# Platform Gate Status Snapshot — 2026-08-11
+
+**Canonical production network:** Base Mainnet (`8453`)  
+**Canonical AETH:** `0xecf7E17faE148C01E1b5008A31Dfd2d1B6608E4e`  
+**This file does not authorize mainnet presale, trading, liquidity, or public funds.**
+
+## Current gates
+
+| Gate | Status | Issue |
+|------|--------|-------|
+| Token deployed + source verified on Base | done | — |
+| Protected Base Sepolia presale + staking rehearsal + full path evidence | **open** | #217 |
+| Owner / treasury / multisig / timelock separation review | open | #217 / #219 |
+| Independent smart-contract review | open | #219 |
+| Formal Base Mainnet launch authorization | **open** | #219 |
+| Trading + liquidity plan (draft) | draft only | `docs/TRADING_AND_LIQUIDITY_PLAN.md` |
+| Stale Polygon-first references cleanup | in progress / residual | #214 |
+
+## Evidence templates (fill after rehearsal)
+
+- `docs/evidence/BASE_SEPOLIA_REHEARSAL_TEMPLATE.md`
+- `docs/evidence/base-sepolia-rehearsal.template.json`
+- Execution checklist: `docs/RELEASE_EXECUTION.md`
+
+## Required path coverage for #217
+
+- Presale success / cancel / refund / claim
+- Treasury withdrawal after valid success only
+- Staking deposit, normal unstake, emergency exit
+- Pause / recovery and unauthorized privilege reverts
+- Immutable packet: addresses, txs, blocks, bytecode hashes, verification URLs, manifest digest
+
+## Non-negotiables
+
+- Testnet rehearsal does **not** authorize Base Mainnet actions.
+- Do not accept public funds or enable production liquidity while #217 or #219 are open.
+- Frontend must fail closed on wrong network and read only canonical Base deployment records.
+
+## Cross-project dependency
+
+Sentinel controlled-redeployment (#210 / #215) and Platform launch are tracked together on the Master Launch Checklist (Sentinel #263). Prefer closing Sentinel Sepolia beneficiary evidence validation and Platform #217 before requesting #219 authorization.


### PR DESCRIPTION
## Summary

Status snapshot and PROJECT_STATUS refresh for 2026-08-11.

### Changes
- `docs/STATUS_2026-08-11.md` — gate table, evidence template pointers, non-negotiables
- `PROJECT_STATUS.md` — last updated 2026-08-11; clarifies trading disabled in release model; links status snapshot

### Explicit non-claims
- Does not mark #217 or #219 complete
- Does not authorize mainnet presale, trading, liquidity, or public funds
- Trading plan remains draft-only

Related: #217, #219, #214